### PR TITLE
[Feature] Option to disable poster from detailed info osd (only matrix osd)

### DIFF
--- a/1080i/Custom_VideoSetting.xml
+++ b/1080i/Custom_VideoSetting.xml
@@ -115,6 +115,15 @@
                     <onclick>Skin.ToggleSetting(osd.showplot)</onclick>
                     <visible>!Skin.HasSetting(osd.usethemeNewOSDSide)</visible>
                 </control>
+                <control type="radiobutton" id="85">
+                    <description>Filter</description>
+                    <include>DefContextButtonGradient</include>
+                    <label>Show poster</label><!-- TODO: add to language -->
+                    <align>left</align>
+                    <selected>!Skin.HasSetting(osd.disableposter)</selected>
+                    <onclick>Skin.ToggleSetting(osd.disableposter)</onclick>
+                    <visible>Skin.HasSetting(osd.usethemeNewOSD)</visible>
+                </control>
                 <control type="radiobutton" id="83">
                     <description>Filter</description>
                     <include>DefContextButtonGradient</include>

--- a/1080i/Custom_VideoSetting.xml
+++ b/1080i/Custom_VideoSetting.xml
@@ -109,7 +109,7 @@
                 <control type="radiobutton" id="82">
                     <description>Filter</description>
                     <include>DefContextButtonGradient</include>
-                    <label>31214</label>
+                    <label>207</label>
                     <align>left</align>
                     <selected>Skin.HasSetting(osd.showplot)</selected>
                     <onclick>Skin.ToggleSetting(osd.showplot)</onclick>
@@ -118,7 +118,7 @@
                 <control type="radiobutton" id="85">
                     <description>Filter</description>
                     <include>DefContextButtonGradient</include>
-                    <label>Show poster</label><!-- TODO: add to language -->
+                    <label>31262</label>
                     <align>left</align>
                     <selected>!Skin.HasSetting(osd.disableposter)</selected>
                     <onclick>Skin.ToggleSetting(osd.disableposter)</onclick>

--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -195,7 +195,7 @@
                     <bottom>50</bottom>
                     <visible>Skin.HasSetting(osd.usethemeNewOSD) + !Skin.HasSetting(osd.usethemeNewOSDSide)</visible>
                     <control type="image">
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                        <visible>!Skin.hasSetting(osd.disableposter) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <left>0</left>
                         <top>-250</top>
                         <width>270</width>
@@ -207,7 +207,7 @@
                         <animation effect="slide" start="0,0" end="0,30" time="150" condition="Window.IsVisible(videoosd)">Conditional</animation>
                     </control>
                     <control type="image">
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                        <visible>!Skin.hasSetting(osd.disableposter) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <left>-1</left>
                         <top>-251</top>
                         <width>272</width>
@@ -219,6 +219,7 @@
                         <animation effect="slide" start="0,0" end="0,30" time="150" condition="Window.IsVisible(videoosd)">Conditional</animation>
                     </control>
                     <control type="image">
+                        <visible>!Skin.hasSetting(osd.disableposter) + [VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))]</visible>
                         <width>260</width>
                         <left>10</left>
                         <height>260</height>
@@ -228,18 +229,34 @@
                         <animation effect="slide" start="0" end="0,-40" time="150" condition="Skin.HasSetting(osd.showplot)">Conditional</animation>
                         <animation effect="slide" start="0" end="0,-19" time="150" condition="Skin.HasSetting(pvr.showtechnicalinfo)">Conditional</animation>
                         <animation effect="slide" start="0,0" end="0,30" time="150" condition="Window.IsVisible(videoosd)">Conditional</animation>
-                        <visible>VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))</visible>
                     </control>
+                    
                     <control type="group">
+                        <visible>!Skin.hasSetting(osd.disableposter)</visible>
                         <left>318</left>
-                        <visible>VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))</visible>
-                        <include>OSDInfoContent</include>
-                        <include>OSDPVRInfoContent</include>
+                        <control type="group">
+                            <visible>VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))</visible>
+                            <include>OSDInfoContent</include>
+                            <include>OSDPVRInfoContent</include>
+                        </control>
+                        <control type="group">
+                            <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                            <include>OSDInfoContent</include>
+                        </control>
                     </control>
+
                     <control type="group">
-                        <left>318</left>
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
-                        <include>OSDInfoContent</include>
+                        <visible>Skin.hasSetting(osd.disableposter)</visible>
+                        <left>20</left>
+                        <control type="group">
+                            <visible>VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))</visible>
+                            <include>OSDInfoContent</include>
+                            <include>OSDPVRInfoContent</include>
+                        </control>
+                        <control type="group">
+                            <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                            <include>OSDInfoContent</include>
+                        </control>
                     </control>
                     <control type="group">
                         <left>20</left>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -277,7 +277,7 @@
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>     $LOCALIZE[37861]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37861]</label>
                             <selected>Skin.HasSetting(homemenu.only.icons)</selected>
                             <onclick>Skin.ToggleSetting(homemenu.only.icons)</onclick>
                             <enable>Skin.HasSetting(home.showicons) + !$EXP[HomeIsVertical]</enable>
@@ -286,7 +286,7 @@
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>     $LOCALIZE[37917]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37917]</label>
                             <selected>Skin.HasSetting(home.show.label)</selected>
                             <onclick>Skin.ToggleSetting(home.show.label)</onclick>
                             <visible>Skin.HasSetting(home.showicons) + !$EXP[HomeIsVertical] + Skin.HasSetting(homemenu.only.icons)</visible>
@@ -474,7 +474,7 @@
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>     $LOCALIZE[37532]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37532]</label>
                             <enable>Skin.HasSetting(home.showclearlogo) + Skin.HasSetting(home.classicwidgets)</enable>
                             <selected>Skin.HasSetting(home.showclearlogoleftbottomclassic)</selected>
                             <onclick>Skin.ToggleSetting(home.showclearlogoleftbottomclassic)</onclick>
@@ -1031,7 +1031,7 @@
                             <include content="DefContextButtonColorbox">
                                 <param name="colorcode" value="$VAR[ColorHighlightSelectbox2]"/>
                             </include>
-                            <label>     $LOCALIZE[37866]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37866]</label>
                             <!--<onclick>ActivateWindow(1107)</onclick>-->
                             <onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">InstallAddon(script.skin.helper.colorpicker)</onclick>
                             <onclick>RunScript(script.skin.helper.colorpicker,skinstring=squarecolor2.name)</onclick>
@@ -1054,7 +1054,7 @@
                             <include content="DefContextButtonColorbox">
                                 <param name="colorcode" value="$VAR[ColorHighlightOtherBar]"/>
                             </include>
-                            <label>     $LOCALIZE[37866]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37866]</label>
                             <!--<onclick>ActivateWindow(1107)</onclick>-->
                             <onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">InstallAddon(script.skin.helper.colorpicker)</onclick>
                             <onclick>RunScript(script.skin.helper.colorpicker,skinstring=focuscolorotherbar.name)</onclick>
@@ -1077,7 +1077,7 @@
                             <include content="DefContextButtonColorbox">
                                 <param name="colorcode" value="$VAR[ColorKodiLogoGradient]"/>
                             </include>
-                            <label>     $LOCALIZE[37866]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37866]</label>
                             <!--<onclick>ActivateWindow(1107)</onclick>-->
                             <onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">InstallAddon(script.skin.helper.colorpicker)</onclick>
                             <onclick>RunScript(script.skin.helper.colorpicker,skinstring=kodilogocolorgradient.name)</onclick>
@@ -1100,7 +1100,7 @@
                             <include content="DefContextButtonColorbox">
                                 <param name="colorcode" value="$VAR[ColorHighlight2]"/>
                             </include>
-                            <label>     $LOCALIZE[37866]</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37866]</label>
                             <!--<onclick>ActivateWindow(1107)</onclick>-->
                             <onclick condition="!System.HasAddon(script.skin.helper.colorpicker)">InstallAddon(script.skin.helper.colorpicker)</onclick>
                             <onclick>RunScript(script.skin.helper.colorpicker,skinstring=focuscolor2.name)</onclick>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -766,6 +766,15 @@
                             <onclick>Skin.ToggleSetting(osd.showplot)</onclick>
                             <enable>!Skin.HasSetting(osd.usethemeNewOSDSide)</enable>
                         </control>
+                        <control type="radiobutton" id="9214" description="Show poster">
+                            <width>1310</width>
+                            <visible>ControlGroup(9100).HasFocus(9103)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>Show poster</label><!-- TODO: add to language -->
+                            <selected>!Skin.HasSetting(osd.disableposter) | [Skin.HasSetting(osd.showinfoonpause) + !Skin.hasSetting(osd.usethemeNewOSD)]</selected>
+                            <onclick>Skin.ToggleSetting(osd.disableposter)</onclick>
+                            <enable>Skin.HasSetting(osd.showinfoonpause) + Skin.hasSetting(osd.usethemeNewOSD)</enable>
+                        </control>
                         <control type="radiobutton" id="9219">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9103)</visible>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -321,8 +321,13 @@
                 <onright condition="!Player.CanRecord | !VideoPlayer.Content(LiveTV)">12</onright>
                 <onright condition="Player.CanRecord + VideoPlayer.Content(LiveTV)">9003</onright>
                 <include>DefOSDUpDown</include>
-                <animation effect="slide" start="0,0" end="300,0" time="150" condition="[Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
-                <animation effect="slide" start="0,0" end="300,0" time="150" condition="[Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                
+                <animation effect="slide" start="0,0" end="300,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="300,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                
+                <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                
                 <usecontrolcoords>true</usecontrolcoords>
                 <control type="button" id="1">
                     <description>Audio</description>
@@ -349,8 +354,12 @@
                 </control>
             </control>
             <control type="grouplist" id="101">
-                <animation effect="slide" start="0,0" end="155,0" time="150" condition="[Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
-                <animation effect="slide" start="0,0" end="155,0" time="150" condition="[Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="155,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="155,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                
+                <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                
                 <left>0</left>
                 <top>13</top>
                 <width>100%</width>


### PR DESCRIPTION
This is my first time working for Kodi... So, Im not sure about the pull request, I just did my best here.


**My problem**
Im running Kodi for windows in my TV.   
Kodi 19 has HDR and automatic turn Windows' HDR when need.  
Im using `Show detailed info when video is paused`   
_The problem starts here_  
When you're playing HDR and the OSD appears and contains an image **the image _(in that case the poster)_ looks extreme ugly**, at least in my setup it does...


**What I think**
Of course I can disable the `detailed info when video is paused` but it is nice to see some info there (like title, episode, etc), I kinda like it.  
I just don't like the way that the image is today, maybe it changes in future, maybe the problem occurs only for me, I don't know. 
I thought about remove the image and adjust the alignments... I could do that... and I did it. 


**What is missing?**
- Translation files
    - Im not sure about the standard for IDs on `.po` files... So I didn't change, if we go further here we need to change then
- Default enabled value for the option
    - I could follow two ways: `set to show` or `set to hide` I make `set to show` but I don't know how make the option to show enabled by default...
- Others OSD?
    - Im using `Matrix OSD` and for now I only changed for that. I also did the conditionals to restrict that. 


<details>
<summary>Skin Settings</summary>
<img src="https://user-images.githubusercontent.com/15933/103439471-1db04100-4c35-11eb-95b4-5ac1def43888.png">
</details>
<details>
<summary>View Options</summary>
<img src="https://user-images.githubusercontent.com/15933/103421934-dd01ea80-4b96-11eb-8ab6-583af3450863.png">
</details>
<details>
<summary>OSD without poster</summary>
<img src="https://user-images.githubusercontent.com/15933/103421578-0457b800-4b95-11eb-880f-83c4ab55fd6c.png">
</details>