### PR TITLE
Improve OSD title width

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -247,7 +247,7 @@
 
                     <control type="group">
                         <visible>Skin.hasSetting(osd.disableposter)</visible>
-                        <left>20</left>
+                        <left>0</left>
                         <control type="group">
                             <visible>VideoPlayer.Content(LiveTV) + !String.IsEmpty(Player.Art(thumb))</visible>
                             <include>OSDInfoContent</include>
@@ -259,7 +259,7 @@
                         </control>
                     </control>
                     <control type="group">
-                        <left>20</left>
+                        <left>0</left>
                         <visible>String.IsEmpty(Player.Art(tvshow.poster)) + String.IsEmpty(Player.Art(poster)) + [!VideoPlayer.Content(LiveTV) | String.IsEmpty(Player.Art(thumb))]</visible>
                         <include>OSDInfoContent</include>
                     </control>

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -2143,6 +2143,20 @@
         </control>
     </include>
 
+    <include name="DefOSDPlayerTVShowTitle">
+        <control type="fadelabel" description="Show">
+            <width>$PARAM[width]</width>
+            <top>40</top>
+            <height>40</height>
+            <font>MediumBold</font>
+            <textcolor>$VAR[OSDPanelWhite70]</textcolor>
+            <pauseatend>6000</pauseatend>
+            <label>$INFO[VideoPlayer.TVShowTitle] - S$INFO[VideoPlayer.Season]E$INFO[VideoPlayer.Episode]</label>
+            <label>$INFO[VideoPlayer.TVShowTitle] - $INFO[VideoPlayer.Title]</label>
+            <visible>$PARAM[visible]</visible>
+        </control>
+    </include>
+
     <include name="def_height">
         <height>$PARAM[height]</height>
     </include>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -866,15 +866,47 @@
             <align>left</align>
             <include content="DefOSDPlayerTitle">
                 <param name="width" value="1100"/>
-                <param name="visible" value="!Skin.HasSetting(furniture.flagiconsosd)"/>
-            </include>
-            <include content="DefOSDPlayerTitle">
-                <param name="width" value="660"/>
-                <param name="visible" value="Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+                <param name="visible" value="!Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.usethemeNewOSD)"/>
             </include>
             <include content="DefOSDPlayerTitle">
                 <param name="width" value="860"/>
                 <param name="visible" value="Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+
+            <!-- WITH POSTER -->
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="1220"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="1080"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="770"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="630"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            
+            <!-- WITHOUT POSTER -->
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="1540"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="1400"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="1090"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTitle">
+                <param name="width" value="950"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
             </include>
         </control>
         <control type="group">

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -841,21 +841,55 @@
             </control>
         </control>
         <control type="group">
+
+            <!-- Content gleich Episoden -->
             <left>0</left>
             <animation effect="slide" start="0" end="0,-80" time="150" condition="Skin.HasSetting(osd.showplot)">Conditional</animation>
             <visible>VideoPlayer.Content(episodes)</visible>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1100"/>
+                <param name="visible" value="!Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="860"/>
+                <param name="visible" value="Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
 
-            <!-- Content gleich Episoden -->
-            <control type="fadelabel" description="Show">
-                <width>1050</width>
-                <top>40</top>
-                <height>40</height>
-                <font>MediumBold</font>
-                <textcolor>$VAR[OSDPanelWhite70]</textcolor>
-                <pauseatend>6000</pauseatend>
-                <label>$INFO[VideoPlayer.TVShowTitle] - S$INFO[VideoPlayer.Season]E$INFO[VideoPlayer.Episode]</label>
-                <label>$INFO[VideoPlayer.TVShowTitle] - $INFO[VideoPlayer.Title]</label>
-            </control>
+            <!-- WITH POSTER -->
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1220"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1080"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="770"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="630"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + !Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            
+            <!-- WITHOUT POSTER -->
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1540"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1400"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + !Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="1090"/>
+                <param name="visible" value="Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
+            <include content="DefOSDPlayerTVShowTitle">
+                <param name="width" value="950"/>
+                <param name="visible" value="!Skin.HasSetting(videoosd.numericrating) + Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(osd.disableposter) + Skin.HasSetting(osd.usethemeNewOSD)"/>
+            </include>
         </control>
         <control type="group">
 

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -312,7 +312,7 @@
             </control>
             <control type="grouplist" id="100">
                 <top>13</top>
-                <left>120</left>
+                <left>100</left>
                 <height>48</height>
                 <itemgap>0</itemgap>
                 <orientation>horizontal</orientation>
@@ -322,8 +322,8 @@
                 <onright condition="Player.CanRecord + VideoPlayer.Content(LiveTV)">9003</onright>
                 <include>DefOSDUpDown</include>
                 
-                <animation effect="slide" start="0,0" end="300,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
-                <animation effect="slide" start="0,0" end="300,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="320,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
+                <animation effect="slide" start="0,0" end="320,0" time="150" condition="!Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>
                 
                 <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))] + !VideoPlayer.Content(LiveTV)">Conditional</animation>
                 <animation effect="slide" start="0,0" end="0,0" time="150" condition="Skin.HasSetting(osd.disableposter) + [Window.IsVisible(fullscreeninfo) | Player.ShowInfo | !String.IsEmpty(Window(home).Property(osdshowinfo)) | [Player.Paused + Skin.HasSetting(osd.showinfoonpause)]] + !String.IsEmpty(Player.Art(thumb)) + VideoPlayer.Content(LiveTV)">Conditional</animation>


### PR DESCRIPTION
After my last changes, I've notice that without the poster we can use more space for the movie title/episode. 
I did tests with movie and tvshow and I figured out some values that looks good to me.
I just dont know about PVR content, I never used, I know nothing... 

I also improve the conditionals to now take into account the numeric rating as well (stars rating uses more space) 
And I kept the same width for `flagiconsosd` and `flagiconsosdnoicons`. Could be different since `flagiconsosdnoicons` consumes less space, but for now its fine. 

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/15933/103460122-b1544100-4d0b-11eb-979a-f4d00a2911d2.png)
![image](https://user-images.githubusercontent.com/15933/103460144-f0829200-4d0b-11eb-867e-522921946096.png)
</details>


<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/15933/103460284-deedba00-4d0c-11eb-82be-3a473bbd5678.png)
![image](https://user-images.githubusercontent.com/15933/103460149-fa0bfa00-4d0b-11eb-8507-f1f8a50939d4.png)
</details>

Ps. For episodes there's an auto scroll effect, the rest of `Adventure Time` title will appears in that scroll... Different of the Movie that only has `...`