### PR TITLE
Select custom media flags

### DIFF
--- a/1080i/Custom_Ratings.xml
+++ b/1080i/Custom_Ratings.xml
@@ -64,7 +64,7 @@
                 <control type="radiobutton" id="100">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Video Resolution</label>
+                    <label>$LOCALIZE[21443]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.resolution)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.resolution)</onclick>
@@ -72,7 +72,7 @@
                 <control type="radiobutton" id="101">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Video Codec</label>
+                    <label>$LOCALIZE[21445]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.videocodec)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.videocodec)</onclick>
@@ -80,7 +80,7 @@
                 <control type="radiobutton" id="102">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Aspect Ratio</label>
+                    <label>$LOCALIZE[21374]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.aspectratio)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.aspectratio)</onclick>
@@ -88,7 +88,7 @@
                 <control type="radiobutton" id="103">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Audio Codec</label>
+                    <label>$LOCALIZE[21446]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.audiocodec)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.audiocodec)</onclick>
@@ -96,7 +96,7 @@
                 <control type="radiobutton" id="104">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Audio Channels</label>
+                    <label>$LOCALIZE[37962]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.audiochannels)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.audiochannels)</onclick>
@@ -104,7 +104,7 @@
                 <control type="radiobutton" id="105">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>HDR</label>
+                    <label>$LOCALIZE[37959]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.hdr)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.hdr)</onclick>
@@ -112,7 +112,7 @@
                 <control type="radiobutton" id="106">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>MPAA Rate</label>
+                    <label>$LOCALIZE[20074]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.mpaa)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.mpaa)</onclick>
@@ -120,7 +120,7 @@
                 <control type="radiobutton" id="107">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Bluray / HD DVD / DVD</label>
+                    <label>$LOCALIZE[37960]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.bluray)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.bluray)</onclick>
@@ -128,7 +128,7 @@
                 <control type="radiobutton" id="108">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>IMDB Top 250</label>
+                    <label>$LOCALIZE[37961]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.top250)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.top250)</onclick>
@@ -136,7 +136,7 @@
                 <control type="radiobutton" id="109">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>Rating</label>
+                    <label>$LOCALIZE[563]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.rating)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.rating)</onclick>

--- a/1080i/Custom_Ratings.xml
+++ b/1080i/Custom_Ratings.xml
@@ -3,11 +3,11 @@
     <defaultcontrol>11</defaultcontrol>
     <controls>
         <include>GlobalOverlay</include>
-        <include>Animation.Common</include>                  
+        <include>Animation.Common</include>
         <control type="group">
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
-            <include>DefDialogBackground</include>                           
+            <include>DefDialogBackground</include>
             <control type="group">
                 <left>24</left>
                 <top>26</top>
@@ -32,7 +32,7 @@
                     <colordiffuse>Black12</colordiffuse>
                     <texture>common/white.png</texture>
                 </control>
-            </control>        
+            </control>
             <control type="image">
                 <top>120</top>
                 <left>8</left>
@@ -46,42 +46,130 @@
                 <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,3)">Conditional</animation>
                 <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,4)">Conditional</animation>
                 <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,5)">Conditional</animation>
-            </control>        
+                <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,6)">Conditional</animation>
+                <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,7)">Conditional</animation>
+                <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,8)">Conditional</animation>
+                <animation effect="slide" end="0,70" time="0" condition="Integer.IsGreater(Container(11).Position,9)">Conditional</animation>
+            </control>
             <control type="grouplist" id="11">
-                <height>490</height>
+                <height>700</height>
                 <width>705</width>
                 <top>120</top>
                 <onright>5</onright>
                 <usecontrolcoords>true</usecontrolcoords>
                 <itemgap>0</itemgap>
                 <scrolltime>0</scrolltime>
-                <control type="radiobutton" id="1">
+                
+                <!-- TODO: language -->
+                <control type="radiobutton" id="100">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
-                    <label>37918</label>
-                    <selected>Skin.HasSetting(furniture.showtomatoesandmetacritics)</selected>
-                    <onclick>Skin.ToggleSetting(furniture.showtomatoesandmetacritics)</onclick>
+                    <label>Video Resolution</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.resolution)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.resolution)</onclick>
                 </control>
-                <control type="radiobutton" id="2">
+                <control type="radiobutton" id="101">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Video Codec</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.videocodec)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.videocodec)</onclick>
+                </control>
+                <control type="radiobutton" id="102">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Aspect Ratio</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.aspectratio)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.aspectratio)</onclick>
+                </control>
+                <control type="radiobutton" id="103">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Audio Codec</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.audiocodec)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.audiocodec)</onclick>
+                </control>
+                <control type="radiobutton" id="104">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Audio Channels</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.audiochannels)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.audiochannels)</onclick>
+                </control>
+                <control type="radiobutton" id="105">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>HDR</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.hdr)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.hdr)</onclick>
+                </control>
+                <control type="radiobutton" id="106">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>MPAA Rate</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.mpaa)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.mpaa)</onclick>
+                </control>
+                <control type="radiobutton" id="107">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Bluray / HD DVD / DVD</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.bluray)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.bluray)</onclick>
+                </control>
+                <control type="radiobutton" id="108">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>IMDB Top 250</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.top250)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.top250)</onclick>
+                </control>
+                <control type="radiobutton" id="109">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>Rating</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>!Skin.HasSetting(furniture.flags.rating)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.rating)</onclick>
+                </control>
+                <control type="radiobutton" id="110">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
+                    <label>$LOCALIZE[37742]$LOCALIZE[31218]</label>
+                    <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                    <selected>Skin.HasSetting(furniture.numericrating)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.numericrating)</onclick>
+                    <enable>!Skin.HasSetting(furniture.flags.rating)</enable>
+                </control>
+                <control type="radiobutton" id="111">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
                     <label>38018</label>
                     <selected>Skin.HasSetting(furniture.showuserrating)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showuserrating)</onclick>
                 </control>
-                <control type="radiobutton" id="3">
+                <control type="radiobutton" id="112">
                     <include>DefContextButtonGradientSelect</include>
                     <label>37920</label>
                     <selected>Skin.HasSetting(furniture.showsubtitles)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showsubtitles)</onclick>
                 </control>
-                <control type="radiobutton" id="4">
+                <control type="radiobutton" id="113">
                     <include>DefContextButtonGradientSelect</include>
                     <label>37921</label>
                     <selected>Skin.HasSetting(furniture.showsubtitles.enable.labels)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showsubtitles.enable.labels)</onclick>
                     <enable>Skin.HasSetting(furniture.showsubtitles)</enable>
-                </control>                
+                </control>
             </control>
             <control type="image">
                 <posx>705</posx>
@@ -106,6 +194,7 @@
                 <texturefocus colordiffuse="$VAR[ColorHighlight]" border="5">common/box.png</texturefocus>
                 <onclick>Close</onclick>
             </control>
-        </control>        
+            <include>DialogSelectlabelInclude</include>
+        </control>
     </controls>
 </window>

--- a/1080i/Custom_VideoSetting.xml
+++ b/1080i/Custom_VideoSetting.xml
@@ -165,7 +165,7 @@
                     <align>left</align>
                     <selected>Skin.HasSetting(osd.coloredicons)</selected>
                     <onclick>Skin.ToggleSetting(osd.coloredicons)</onclick>
-                    <enable>Skin.HasSetting(furniture.flagiconsosd)</enable>
+                    <enable>Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</enable>
                 </control>
                 <control type="radiobutton" id="97">
                     <description>Handlung</description>

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -1323,6 +1323,7 @@
                     <align>left</align>
                     <selected>Skin.HasSetting(furniture.coloredicons)</selected>
                     <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
+                    <visible>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</visible>
                 </control>
                 <control type="radiobutton" id="9087">
                     <include>DefContextButtonGradient</include>
@@ -1346,7 +1347,7 @@
                     <label>31195</label>
                     <onclick>ReloadSkin()</onclick>
                     <visible>Skin.HasSetting(DebugInfo)</visible>
-                </control>               
+                </control> 
             </control>
         </control>
     </include>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -1992,6 +1992,43 @@
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_UserMeter)]%</label>
             </control>
         </control>
+        <control type="grouplist">
+            <include>Animation.FurnitureVisible</include>
+            <visible>Skin.HasSetting(furniture.flags)</visible>
+            <!--<visible>[Container.Content(movies) + !Control.IsVisible(501)] | [Container.Content(episodes) + !Control.IsVisible(501)] | [Container.Content(tvshows) + !Control.IsVisible(501)] | [Container.Content(seasons) + !Control.IsVisible(501)] | Window.IsVisible(DialogVideoInfo.xml)</visible>-->
+            <visible>[Container.Content(movies) | Container.Content(episodes)] | [Window.IsVisible(home) + ControlGroup(301).HasFocus() + [String.IsEqual(ListItem.DBType,movie) | String.IsEqual(ListItem.DBType,episode)] + [Skin.HasSetting(home.vertical) + Skin.HasSetting(home.vertical.widgets)] + !Skin.HasSetting(hide.furniture.flags.vertical.widgets)]</visible>
+            <visible>!String.IsEqual(ListItem.Label,..)</visible>
+            <include>Animation.FadeIn</include>
+            <include>Animation.FadeOut</include>
+            <left>SidePad</left>
+            <centerbottom>NavBarPad</centerbottom>
+            <width>1400</width>
+            <height>120</height>
+            <orientation>horizontal</orientation>
+            <align>left</align>
+            <itemgap>3</itemgap>
+            <usecontrolcoords>true</usecontrolcoords>
+
+            <control type="image" description="Duration">
+                <width>48</width>
+                <height>64</height>
+                <centertop>50%</centertop>
+                <texture colordiffuse="Dark1">flags/time.png</texture>
+                <aspectratio align="left">scale</aspectratio>
+                <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
+            </control>
+            <control type="label" description="Duration">
+                <width>auto</width>
+                <centertop>50%</centertop>
+                <height>64</height>
+                <align>left</align>
+                <aligny>center</aligny>
+                <label>$VAR[LabelDurationTimeCheck]  </label>
+                <font>Flag</font>
+                <textcolor>Dark1</textcolor>
+                <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
+            </control>
+        </control>
     </include>
 
     <include name="Furniture_Hub_Flags">

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -1665,20 +1665,20 @@
                     <visible>!ListItem.IsCollection</visible>
                 </control>
             </control>
-            <control type="image">
+            <control type="image" description="Video Resolution">
                 <width min="20" max="90">auto</width>
                 <height>70</height>
                 <left>-10</left>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">$INFO[ListItem.VideoResolution,flags/color/resolution/,.png]</texture>
                 <aspectratio align="left">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution) + !String.Contains(ListItem.Path,videodb://movies/sets,left)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.resolution) + !String.IsEmpty(ListItem.VideoResolution) + !String.Contains(ListItem.Path,videodb://movies/sets,left)</visible>
             </control>
-            <include content="Def_Flags_Furniture_Small">
+            <include content="Def_Flags_Furniture_Small" condition="!Skin.HasSetting(furniture.flags.rating)">
                 <param name="Star" value="Flagstar" />
                 <param name="visible" value="!Skin.HasSetting(furniture.numericrating)" />
             </include>
-            <control type="label">
+            <control type="label" description="Rating">
                 <left>-16</left>
                 <width min="48">auto</width>
                 <centertop>50%</centertop>
@@ -1688,7 +1688,7 @@
                 <label>$INFO[ListItem.Rating]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
-                <visible>Skin.HasSetting(furniture.numericrating)</visible>
+                <visible>Skin.HasSetting(furniture.numericrating) + !Skin.HasSetting(furniture.flags.rating)</visible>
             </control>
             <control type="image">
                 <width>48</width>
@@ -1711,39 +1711,39 @@
                 <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Video Codec">
                 <width min="20" max="100">auto</width>
                 <height>60</height>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">$INFO[ListItem.VideoCodec,flags/color/source/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoCodec)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.videocodec) + !String.IsEmpty(ListItem.VideoCodec)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Aspect Ratio">
                 <width min="20" max="80">auto</width>
                 <height>60</height>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">$INFO[ListItem.VideoAspect,flags/color/aspectratio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoAspect)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.aspectratio) + !String.IsEmpty(ListItem.VideoAspect)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio Codec">
                 <width min="20" max="108">auto</width>
                 <height>60</height>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags/color/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.audiocodec) + !String.IsEmpty(ListItem.AudioCodec)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio Channels">
                 <width min="20" max="80">auto</width>
                 <height>60</height>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">$INFO[ListItem.AudioChannels,flags/color/channels/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioChannels)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.audiochannels) + !String.IsEmpty(ListItem.AudioChannels)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Video Resolution">
                 <width>48</width>
                 <height>64</height>
                 <centertop>50%</centertop>
@@ -1751,7 +1751,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Video">
                 <width min="128">auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1762,7 +1762,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio">
                 <width>48</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1770,7 +1770,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec)</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Audio">
                 <width>auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1781,24 +1781,24 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
                 <height>64</height>
                 <left>10</left>
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="MPAA">
                 <width min="20" max="100">auto</width>
                 <height>64</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[ColorRating]" fallback="flags/fallback.png">$VAR[RatingFlagVar]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.MPAA) + Skin.HasSetting(furniture.coloredicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.mpaa) + !String.IsEmpty(ListItem.MPAA) + Skin.HasSetting(furniture.coloredicons)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Duration">
                 <width>48</width>
                 <height>64</height>
                 <centertop>50%</centertop>
@@ -1806,7 +1806,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Duration">
                 <width>auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1817,7 +1817,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="3D">
                 <width>64</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1825,44 +1825,44 @@
                 <texture>flags/color/other/3D.png</texture>
                 <visible>ListItem.IsStereoscopic</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Bluray">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <left>10</left>
                 <texture>flags/color/other/$VAR[ImageBluray].png</texture>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>[String.Contains(ListItem.FilenameAndPath,bluray) | String.Contains(ListItem.FilenameAndPath,bdrip) | String.Contains(ListItem.FilenameAndPath,bd25) | String.Contains(ListItem.FilenameAndPath,bd50)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="HD DVD">
                 <width>94</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture>flags/hddvd.png</texture>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>String.Contains(ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="DVD">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture>flags/color/other/dvd.png</texture>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>String.Contains(ListItem.FilenameAndPath,dvd) + !String.Contains(ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="IMDB Top 250">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture colordiffuse="Dark1">flags/imdb.png</texture>
-                <visible>!String.IsEmpty(ListItem.Top250)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.top250) + !String.IsEmpty(ListItem.Top250)</visible>
             </control>
             <include condition="Skin.HasSetting(furniture.showsubtitles)">Subtitles_Furniture</include>
-            <control type="image">
+            <control type="image" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>33</width>
@@ -1870,7 +1870,7 @@
                 <left>15</left>
                 <texture background="true" colordiffuse="$VAR[ColorUserrating]">backg/userrating_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1880,7 +1880,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[ListItem.UserRating].0</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>33</width>
@@ -1888,7 +1888,7 @@
                 <left>15</left>
                 <texture background="true">backg/mc.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1898,7 +1898,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1907,7 +1907,7 @@
                 <left>15</left>
                 <texture background="true">$VAR[RottenTomatoesColored]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1925,7 +1925,7 @@
                 <left>20</left>
                 <texture background="true" colordiffuse="$VAR[ColorUserrating]">backg/userrating_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1935,7 +1935,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[ListItem.UserRating].0</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>40</width>
@@ -1943,7 +1943,7 @@
                 <left>30</left>
                 <texture background="true">backg/mc.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1953,7 +1953,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1962,7 +1962,7 @@
                 <left>30</left>
                 <texture background="true">$VAR[RottenTomatoesColored]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1972,7 +1972,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_UserMeter)) + !ListItem.IsCollection  + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1981,7 +1981,7 @@
                 <left>30</left>
                 <texture background="true">$VAR[RottenTomatoesAudienceColored]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_UserMeter)) + !ListItem.IsCollection  + Skin.HasSetting(furniture.showtomatoesandmetacritics)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -1283,21 +1283,21 @@
                     <textcolor>Dark1</textcolor>
                     <visible>!ListItem.IsCollection</visible>
                 </control>
-            </control>            
-            <control type="image">
+            </control>
+            <control type="image" description="Video Resolution">
                 <width min="20" max="70">auto</width>
                 <height>48</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/resolution/fallback.png">$INFO[ListItem.VideoResolution,flags/white/resolution/,.png]</texture>
                 <aspectratio align="left">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution) + !String.Contains(ListItem.Path,videodb://movies/sets,left)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.resolution) + !String.IsEmpty(ListItem.VideoResolution) + !String.Contains(ListItem.Path,videodb://movies/sets,left)</visible>
             </control>
-            <include content="Def_Flags_Furniture_Small">
+            <include content="Def_Flags_Furniture_Small" condition="!Skin.HasSetting(furniture.flags.rating)">
                 <param name="Star" value="Flagstar" />
                 <param name="visible" value="!Skin.HasSetting(furniture.numericrating)" />
                 <param name="color" value="Dark1" />
             </include>
-            <control type="label">
+            <control type="label" description="Rating">
                 <left>-16</left>
                 <width min="48">auto</width>
                 <centertop>50%</centertop>
@@ -1307,7 +1307,7 @@
                 <label>$INFO[ListItem.Rating]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
-                <visible>Skin.HasSetting(furniture.numericrating)</visible>
+                <visible>Skin.HasSetting(furniture.numericrating) + !Skin.HasSetting(furniture.flags.rating)</visible>
             </control>
             <control type="image">
                 <width>48</width>
@@ -1330,39 +1330,39 @@
                 <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Video Codec">
                 <width min="20" max="120">auto</width>
                 <height>48</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">$INFO[ListItem.VideoCodec,flags/white/source/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoCodec) + !Skin.HasSetting(furniture.coloredicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.videocodec) + !String.IsEmpty(ListItem.VideoCodec) + !Skin.HasSetting(furniture.coloredicons)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Aspect Ratio">
                 <width min="20" max="80">auto</width>
                 <height>55</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">$INFO[ListItem.VideoAspect,flags/aspectratio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoAspect) + !Skin.HasSetting(furniture.coloredicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.aspectratio) + !String.IsEmpty(ListItem.VideoAspect) + !Skin.HasSetting(furniture.coloredicons)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio Codec">
                 <width min="20" max="108">auto</width>
                 <height>64</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags3/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec) + !Skin.HasSetting(furniture.coloredicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.audiocodec) + !String.IsEmpty(ListItem.AudioCodec) + !Skin.HasSetting(furniture.coloredicons)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio Channels">
                 <width min="20" max="80">auto</width>
                 <height>45</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">$INFO[ListItem.AudioChannels,flags/channels/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioChannels)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.audiochannels) + !String.IsEmpty(ListItem.AudioChannels)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Video Resolution">
                 <width>48</width>
                 <height>64</height>
                 <centertop>50%</centertop>
@@ -1370,7 +1370,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Video">
                 <width min="128">auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1381,7 +1381,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Audio">
                 <width>48</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1389,7 +1389,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec)</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Audio">
                 <width>auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1400,23 +1400,23 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.AudioCodec)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="HDR">
                 <width min="20" max="80">auto</width>
                 <height>60</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="MPAA">
                 <width min="20" max="100">auto</width>
                 <height>64</height>
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">$VAR[RatingFlagVar]</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.MPAA) + !Skin.HasSetting(furniture.coloredicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.mpaa) + !String.IsEmpty(ListItem.MPAA) + !Skin.HasSetting(furniture.coloredicons)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Duration">
                 <width>48</width>
                 <height>64</height>
                 <centertop>50%</centertop>
@@ -1424,7 +1424,7 @@
                 <aspectratio align="left">scale</aspectratio>
                 <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
             </control>
-            <control type="label">
+            <control type="label" description="Duration">
                 <width>auto</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1435,7 +1435,7 @@
                 <textcolor>Dark1</textcolor>
                 <visible>!String.IsEmpty(ListItem.Duration(mins)) + [Control.IsVisible(500) | Control.IsVisible(53) | Control.IsVisible(52) | Control.IsVisible(55)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="3D">
                 <width>64</width>
                 <centertop>50%</centertop>
                 <height>64</height>
@@ -1443,47 +1443,47 @@
                 <texture colordiffuse="Dark1">flags/3D.png</texture>
                 <visible>ListItem.IsStereoscopic</visible>
             </control>
-            <control type="image">
+            <control type="image" description="Bluray">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <left>10</left>
                 <texture colordiffuse="Dark1">flags/$VAR[ImageBluray].png</texture>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>[String.Contains(ListItem.FilenameAndPath,bluray) | String.Contains(ListItem.FilenameAndPath,bdrip) | String.Contains(ListItem.FilenameAndPath,bd25) | String.Contains(ListItem.FilenameAndPath,bd50)]</visible>
             </control>
-            <control type="image">
+            <control type="image" description="HD DVD">
                 <width>94</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <left>10</left>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture colordiffuse="Dark1">flags/hddvd.png</texture>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>String.Contains(ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="DVD">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <left>10</left>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture colordiffuse="Dark1">flags/dvd.png</texture>
-                <visible>Skin.HasSetting(furniture.flagicons)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.bluray)</visible>
                 <visible>String.Contains(ListItem.FilenameAndPath,dvd) + !String.Contains(ListItem.FilenameAndPath,hddvd)</visible>
             </control>
-            <control type="image">
+            <control type="image" description="IMDB Top 250">
                 <width>84</width>
                 <centertop>50%</centertop>
                 <height>64</height>
                 <left>0</left>
                 <aspectratio aligny="center" align="center">keep</aspectratio>
                 <texture colordiffuse="Dark1">flags/imdb.png</texture>
-                <visible>!String.IsEmpty(ListItem.Top250)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.top250) + !String.IsEmpty(ListItem.Top250)</visible>
             </control>
             <include condition="Skin.HasSetting(furniture.showsubtitles)">Subtitles_Furniture</include>
-            <control type="image">
+            <control type="image" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>33</width>
@@ -1491,7 +1491,7 @@
                 <left>15</left>
                 <texture colordiffuse="Dark1" background="true">backg/userrating_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1501,7 +1501,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[ListItem.UserRating].0</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <include>Animation.FadeIn</include>
                 <centertop>50%</centertop>
@@ -1510,7 +1510,7 @@
                 <left>15</left>
                 <texture colordiffuse="Dark1" background="true">backg/mc_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1520,7 +1520,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1529,7 +1529,7 @@
                 <left>15</left>
                 <texture colordiffuse="Dark1" background="true">$VAR[RottenTomatoes]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + !Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1539,7 +1539,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>38</width>
@@ -1547,7 +1547,7 @@
                 <left>20</left>
                 <texture colordiffuse="Dark1" background="true">backg/userrating_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="User rating">
                 <visible>!String.IsEmpty(ListItem.UserRating) + Skin.HasSetting(furniture.showuserrating) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1557,7 +1557,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[ListItem.UserRating].0</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>38</width>
@@ -1565,7 +1565,7 @@
                 <left>35</left>
                 <texture colordiffuse="Dark1" background="true">backg/mc_white.png</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1575,7 +1575,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.Metacritic_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1584,7 +1584,7 @@
                 <left>35</left>
                 <texture colordiffuse="Dark1" background="true">$VAR[RottenTomatoes]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)) + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>
@@ -1594,7 +1594,7 @@
                 <textcolor>Dark2</textcolor>
                 <label>$INFO[Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_Rating)]%</label>
             </control>
-            <control type="image">
+            <control type="image" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_UserMeter)) + !ListItem.IsCollection  + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <fadetime>150</fadetime>
                 <centertop>50%</centertop>
@@ -1603,7 +1603,7 @@
                 <left>35</left>
                 <texture colordiffuse="Dark1" background="true">$VAR[RottenTomatoesAudience]</texture>
             </control>
-            <control type="label">
+            <control type="label" description="Rotten Tomatoes">
                 <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.RottenTomatoes_UserMeter)) + !ListItem.IsCollection  + Skin.HasSetting(furniture.showtomatoesandmetacritics) + Skin.HasSetting(furniture.flagicons)</visible>
                 <centertop>50%</centertop>
                 <width>auto</width>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -576,6 +576,7 @@
                     <align>left</align>
                     <selected>Skin.HasSetting(furniture.coloredicons)</selected>
                     <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
+                    <visible>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</visible>
                 </control>
                 <control type="radiobutton" id="9585">
                     <include>DefContextButtonGradient</include>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1522,15 +1522,6 @@
                             <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</enable>
                         </control>
-                        <control type="radiobutton" id="9269" description="Numeric Rating">
-                            <width>1310</width>
-                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
-                            <include>DefSettingsButtonGradient</include>
-                            <label>$LOCALIZE[37742]$LOCALIZE[31218]</label>
-                            <selected>Skin.HasSetting(furniture.numericrating)</selected>
-                            <onclick>Skin.ToggleSetting(furniture.numericrating)</onclick>
-                            <enable>!Skin.HasSetting(furniture.flags)</enable>
-                        </control>
                         <control type="button" id="9272" description="Rating fallback label">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
@@ -1543,7 +1534,7 @@
                             <onclick condition="String.IsEqual(Skin.String(RatingFallback),3)">Skin.SetString(RatingFallback,4)</onclick>
                             <onclick condition="String.IsEqual(Skin.String(RatingFallback),4)">Skin.SetString(RatingFallback,)</onclick>
                         </control>
-                        <control type="radiobutton" id="9273" description="Numeric Rating">
+                        <control type="radiobutton" id="9273" description="Unwatched episodes">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
@@ -1555,7 +1546,7 @@
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsLabel</include>
                             <label>37752</label>
-                        </control>                        
+                        </control>
                         <control type="radiobutton" id="9276" description="Now Playing">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1496,11 +1496,19 @@
                             <selected>!Skin.HasSetting(furniture.flags)</selected>
                             <onclick>Skin.ToggleSetting(furniture.flags)</onclick>
                         </control>
+                        <control type="button" id="9263" description="Numeric Rating">
+                            <width>1310</width>
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37919]</label>
+                            <onclick>ActivateWindow(1266)</onclick>
+                            <enable>!Skin.HasSetting(furniture.flags)</enable>
+                        </control>
                         <control type="radiobutton" id="9261" description="FlagsIcons">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>31246</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[31246]</label>
                             <selected>Skin.HasSetting(furniture.flagicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.flagicons)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags)</enable>
@@ -1509,7 +1517,7 @@
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>37521</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37521]</label>
                             <selected>Skin.HasSetting(furniture.coloredicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</enable>
@@ -1518,17 +1526,9 @@
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
-                            <label>31218</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[31218]</label>
                             <selected>Skin.HasSetting(furniture.numericrating)</selected>
                             <onclick>Skin.ToggleSetting(furniture.numericrating)</onclick>
-                            <enable>!Skin.HasSetting(furniture.flags)</enable>
-                        </control>
-                        <control type="button" id="9263" description="Numeric Rating">
-                            <width>1310</width>
-                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
-                            <include>DefSettingsButtonGradient</include>
-                            <label>37919</label>
-                            <onclick>ActivateWindow(1266)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags)</enable>
                         </control>
                         <control type="button" id="9272" description="Rating fallback label">

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -743,7 +743,7 @@
                             <include>DefSettingsButtonGradient</include>
                             <selected>Skin.HasSetting(furniture.flagiconsosdnoicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.flagiconsosdnoicons)</onclick>
-                            <label>31246</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[31246]</label>
                             <enable>Skin.HasSetting(furniture.flagiconsosd)</enable>
                         </control>
                         <control type="radiobutton" id="9216">
@@ -752,7 +752,7 @@
                             <include>DefSettingsButtonGradient</include>
                             <selected>Skin.HasSetting(osd.coloredicons)</selected>
                             <onclick>Skin.ToggleSetting(osd.coloredicons)</onclick>
-                            <label>37521</label>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37521]</label>
                             <enable>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons)</enable>
                         </control>
                         <control type="radiobutton" id="9217">
@@ -1503,6 +1503,7 @@
                             <label>31246</label>
                             <selected>Skin.HasSetting(furniture.flagicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.flagicons)</onclick>
+                            <enable>!Skin.HasSetting(furniture.flags)</enable>
                         </control>
                         <control type="radiobutton" id="9262">
                             <width>1310</width>
@@ -1511,7 +1512,8 @@
                             <label>37521</label>
                             <selected>Skin.HasSetting(furniture.coloredicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
-                        </control>                        
+                            <enable>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</enable>
+                        </control>
                         <control type="radiobutton" id="9269" description="Numeric Rating">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
@@ -1527,6 +1529,7 @@
                             <include>DefSettingsButtonGradient</include>
                             <label>37919</label>
                             <onclick>ActivateWindow(1266)</onclick>
+                            <enable>!Skin.HasSetting(furniture.flags)</enable>
                         </control>
                         <control type="button" id="9272" description="Rating fallback label">
                             <width>1310</width>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1496,15 +1496,7 @@
                             <selected>!Skin.HasSetting(furniture.flags)</selected>
                             <onclick>Skin.ToggleSetting(furniture.flags)</onclick>
                         </control>
-                        <control type="button" id="9263" description="Numeric Rating">
-                            <width>1310</width>
-                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
-                            <include>DefSettingsButtonGradient</include>
-                            <label>$LOCALIZE[37742]$LOCALIZE[37919]</label>
-                            <onclick>ActivateWindow(1266)</onclick>
-                            <enable>!Skin.HasSetting(furniture.flags)</enable>
-                        </control>
-                        <control type="radiobutton" id="9261" description="FlagsIcons">
+                        <control type="radiobutton" id="9261" description="Flags Icons">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
@@ -1513,7 +1505,7 @@
                             <onclick>Skin.ToggleSetting(furniture.flagicons)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags)</enable>
                         </control>
-                        <control type="radiobutton" id="9262">
+                        <control type="radiobutton" id="9262" description="Flags Color Icons">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
@@ -1521,6 +1513,14 @@
                             <selected>Skin.HasSetting(furniture.coloredicons)</selected>
                             <onclick>Skin.ToggleSetting(furniture.coloredicons)</onclick>
                             <enable>!Skin.HasSetting(furniture.flags) + Skin.HasSetting(furniture.flagicons)</enable>
+                        </control>
+                        <control type="button" id="9263" description="Select media flags">
+                            <width>1310</width>
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[37919]</label>
+                            <onclick>ActivateWindow(1266)</onclick>
+                            <enable>!Skin.HasSetting(furniture.flags)</enable>
                         </control>
                         <control type="button" id="9272" description="Rating fallback label">
                             <width>1310</width>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2582,6 +2582,22 @@ msgctxt "#37958"
 msgid "Homemenu options"
 msgstr ""
 
+msgctxt "#37959"
+msgid "HDR"
+msgstr ""
+
+msgctxt "#37960"
+msgid "Blu-ray / HD DVD / DVD"
+msgstr ""
+
+msgctxt "#37961"
+msgid "IMDB Top 250"
+msgstr ""
+
+msgctxt "#37962"
+msgid "Audio Channels"
+msgstr ""
+
 msgctxt "#31001"
 msgid "Backup / Restore"
 msgstr "Backup / Restore"

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -2423,7 +2423,7 @@ msgid "RottenTomatoes & Metacritic"
 msgstr ""
 
 msgctxt "#37919"
-msgid "Select additional media flags"
+msgid "Select media flags"
 msgstr ""
 
 msgctxt "#37920"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -2368,6 +2368,22 @@ msgctxt "#37958"
 msgid "Homemenu options"
 msgstr "Hauptmenu Optionen"
 
+msgctxt "#37959"
+msgid "HDR"
+msgstr ""
+
+msgctxt "#37960"
+msgid "Blu-ray / HD DVD / DVD"
+msgstr ""
+
+msgctxt "#37961"
+msgid "IMDB Top 250"
+msgstr ""
+
+msgctxt "#37962"
+msgid "Audio Channels"
+msgstr "Audio Kanäle"
+
 msgctxt "#31001"
 msgid "Backup / Restore"
 msgstr "Backup / Restore"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -2257,7 +2257,7 @@ msgid "RottenTomatoes & Metacritic"
 msgstr ""
 
 msgctxt "#37919"
-msgid "Select additional media flags"
+msgid "Select media flags"
 msgstr "Zusätzliche Medieninfos auswählen"
 
 msgctxt "#37920"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -2423,7 +2423,7 @@ msgid "RottenTomatoes & Metacritic"
 msgstr "로튼토마토 & 메타크리틱"
 
 msgctxt "#37919"
-msgid "Select additional media flags"
+msgid "Select media flags"
 msgstr "추가 미디어 정보 선택"
 
 msgctxt "#37920"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -2582,6 +2582,22 @@ msgctxt "#37958"
 msgid "Homemenu options"
 msgstr ""
 
+msgctxt "#37959"
+msgid "HDR"
+msgstr ""
+
+msgctxt "#37960"
+msgid "Blu-ray / HD DVD / DVD"
+msgstr ""
+
+msgctxt "#37961"
+msgid "IMDB Top 250"
+msgstr ""
+
+msgctxt "#37962"
+msgid "Audio Channels"
+msgstr ""
+
 msgctxt "#31001"
 msgid "Backup / Restore"
 msgstr "백업 / 복원"

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -2423,7 +2423,7 @@ msgid "RottenTomatoes & Metacritic"
 msgstr ""
 
 msgctxt "#37919"
-msgid "Select additional media flags"
+msgid "Select media flags"
 msgstr ""
 
 msgctxt "#37920"

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -2434,6 +2434,22 @@ msgctxt "#37921"
 msgid "Subtitle extended info"
 msgstr ""
 
+msgctxt "#37959"
+msgid "HDR"
+msgstr ""
+
+msgctxt "#37960"
+msgid "Blu-ray / HD DVD / DVD"
+msgstr ""
+
+msgctxt "#37961"
+msgid "IMDB Top 250"
+msgstr ""
+
+msgctxt "#37962"
+msgid "Audio Channels"
+msgstr ""
+
 msgctxt "#31001"
 msgid "Backup / Restore"
 msgstr "Copia de seguridad / Restaurar"


### PR DESCRIPTION
What I did:
- Created a settings in `forniture/media flags` to select which flags you want to see ([example](https://user-images.githubusercontent.com/15933/106672612-3e5b1600-65a8-11eb-9ae3-3e54387981e2.png))
- Changed the forniture flags icons (color and not) to follow those settings ([example](https://user-images.githubusercontent.com/15933/106672797-9560eb00-65a8-11eb-88f4-4c650c03ace7.png))
- Fixed a bug (I think so) that removes the `duration` when `media flags` was disable in some views (like icons and big icons). Now the `duration` will always appear in those views. ([example](https://user-images.githubusercontent.com/15933/106673054-f7215500-65a8-11eb-8b7a-deedc15e488a.png))

What are missing:
- **String.po** I have create some strings and I dont know the best way to add it to string.po files, need help on this.
- **Tests** I did my tests but I dont know if I missed somewhere...

I will not touch:
- I didnt change information ([example](https://user-images.githubusercontent.com/15933/106673285-4a93a300-65a9-11eb-85da-f3e7bc6a0b1e.png)) and osd, I think this PR should be only related to the views, you know?
- I didnt change the media-flags without icons
    - With icons disable, you can only change `my rating` and `subtitle`, like before ([example](https://user-images.githubusercontent.com/15933/106672186-947b8980-65a7-11eb-9bea-041198b1f507.png))
    - With icons disable, I didnt change the flag's format ([example](https://user-images.githubusercontent.com/15933/106672287-baa12980-65a7-11eb-9de2-5a90586a2513.png))

 