### PR TITLE
[ViewType] Enable View_510 for Seasons and Episodes

### DIFF
--- a/1080i/Custom_SetViewtype.xml
+++ b/1080i/Custom_SetViewtype.xml
@@ -141,7 +141,6 @@
                     <onclick>Container.SetViewMode(510)</onclick>
                     <onclick>Close</onclick>
                     <enable>!Container.Content(videos) + !Container.Content(actors)</enable>
-                    <visible>!Container.Content(seasons) + !Container.Content(episodes)</visible>
                 </control>
                 <control type="button" id="3101">
                     <width>413</width>

--- a/1080i/View_510_Minimal.xml
+++ b/1080i/View_510_Minimal.xml
@@ -4,7 +4,7 @@
 
     <include name="510Content">
         <!--<oninfo condition="ListItem.IsCollection">ActivateWindow(1132)</oninfo>-->
-        <visible>Container.Content(movies) | Container.Content(tvshows)</visible>
+        <visible>Container.Content(movies) | Container.Content(tvshows) | Container.Content(seasons) | Container.Content(episodes)</visible>
         <include content="forced_view" condition="Skin.HasSetting(enable.forcedviews)">
             <param name="string" value="$LOCALIZE[37590]" />
         </include>


### PR DESCRIPTION
I would like to enable the 510 "Big-flix Icons" for seasons because Im using Poster for seasons and 520 only show Fanart (landscape or  thumbs).

I've tested and I did not see problems on that.  
Should we enable even for episodes? 


**Big-Flix (the View_510)**
![image](https://user-images.githubusercontent.com/15933/107146345-7fa04c80-693f-11eb-97f8-0330502785b8.png)

**Big-Flix Episodes (the view 520)**
![image](https://user-images.githubusercontent.com/15933/107146373-b5ddcc00-693f-11eb-9313-9259caddfcd5.png)
