### PR TITLE
[ViewType] Option to hide scrollbar when scrolling

### DIFF
--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -62,7 +62,7 @@
     <include name="scrollbar_hor">
         <onback>50</onback>
         <left>90</left>
-        <width>1745</width>
+        <width>1740</width>
         <bottom>200</bottom>
         <orientation>horizontal</orientation>
         <height>8</height>
@@ -77,7 +77,7 @@
     <include name="scrollbar_hor_weather">
         <onback>50</onback>
         <left>90</left>
-        <width>1745</width>
+        <width>1740</width>
         <bottom>210</bottom>
         <orientation>horizontal</orientation>
         <height>8</height>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -60,18 +60,21 @@
     </include>
 
     <include name="scrollbar_hor">
-        <onback>50</onback>
-        <left>90</left>
-        <width>1740</width>
-        <bottom>200</bottom>
-        <orientation>horizontal</orientation>
-        <height>8</height>
-        <onup>50</onup>
-        <ondown condition="!Skin.HasSetting(global.kioskmode) + !Control.IsVisible(510) + !Control.IsVisible(520) + !Control.IsVisible(53)">390000</ondown>
-        <texturesliderbackground border="4" colordiffuse="Dark4">scrollbar/scrollv.png</texturesliderbackground>
-        <texturesliderbar border="4" colordiffuse="Dark3">scrollbar/scrollv.png</texturesliderbar>
-        <texturesliderbarfocus border="4" colordiffuse="Dark2">scrollbar/scrollv.png</texturesliderbarfocus>
-        <animation effect="fade" start="100" end="0" time="400" condition="!Control.HasFocus($PARAM[scrollid]) + !Container.Scrolling">Conditional</animation>
+        <param name="showscroll" default="true" />
+        <definition>
+          <onback>50</onback>
+          <left>90</left>
+          <width>1740</width>
+          <bottom>200</bottom>
+          <orientation>horizontal</orientation>
+          <height>8</height>
+          <onup>50</onup>
+          <ondown condition="!Skin.HasSetting(global.kioskmode) + !Control.IsVisible(510) + !Control.IsVisible(520) + !Control.IsVisible(53)">390000</ondown>
+          <texturesliderbackground border="4" colordiffuse="Dark4">scrollbar/scrollv.png</texturesliderbackground>
+          <texturesliderbar border="4" colordiffuse="Dark3">scrollbar/scrollv.png</texturesliderbar>
+          <texturesliderbarfocus border="4" colordiffuse="Dark2">scrollbar/scrollv.png</texturesliderbarfocus>
+          <animation effect="fade" start="100" end="0" time="400" condition="!Control.HasFocus($PARAM[scrollid]) + [!Container.Scrolling | $PARAM[showscroll]]">Conditional</animation>
+        </definition>
     </include>
 
     <include name="scrollbar_hor_weather">

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -63,8 +63,8 @@
         <param name="showscroll" default="true" />
         <definition>
           <onback>50</onback>
-          <left>90</left>
-          <width>1740</width>
+          <left>SidePad</left>
+          <width>1760</width>
           <bottom>200</bottom>
           <orientation>horizontal</orientation>
           <height>8</height>
@@ -79,8 +79,8 @@
 
     <include name="scrollbar_hor_weather">
         <onback>50</onback>
-        <left>90</left>
-        <width>1740</width>
+        <left>SidePad</left>
+        <width>1760</width>
         <bottom>210</bottom>
         <orientation>horizontal</orientation>
         <height>8</height>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -250,7 +250,7 @@
     <variable name="LabelwidgetListType">
         <value condition="String.IsEmpty(Container(211).ListItem.Property(widgetListType))">$LOCALIZE[571]</value>
         <value condition="String.IsEqual(Container(211).ListItem.Property(widgetListType),fixedlist)">$LOCALIZE[37793]</value>
-        <value condition="String.IsEqual(Container(211).ListItem.Property(widgetListType),wraplist)">$LOCALIZE[37805]</value>
+        <value condition="String.IsEqual(Container(211).ListItem.Property(widgetListType),wraplist)">$LOCALIZE[31148]</value>
         <value condition="String.IsEqual(Container(211).ListItem.Property(widgetListType),list)">$LOCALIZE[37792]</value>
     </variable>
 

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -470,6 +470,14 @@
                     <visible>Control.IsVisible(510) | Control.IsVisible(520)</visible>
                     <visible>Skin.HasSetting(BlurEnabled)</visible>
                 </control>
+                <control type="radiobutton" id="9069">
+                    <include>DefContextButtonGradient</include>
+                    <align>left</align>
+                    <label>37805</label>
+                    <selected>!Skin.HasSetting(ShowScrollbar510)</selected>
+                    <onclick>Skin.ToggleSetting(ShowScrollbar510)</onclick>
+                    <visible>Control.IsVisible(510) | Control.IsVisible(520)</visible>
+                </control>
                 <control type="button" id="9070" description="Netflix Icon Size">
                     <include>DefContextButtonGradient</include>
                     <align>left</align>

--- a/1080i/View_510_Minimal.xml
+++ b/1080i/View_510_Minimal.xml
@@ -238,6 +238,7 @@
             <control type="scrollbar" id="1651">
                 <bottom>162</bottom>
                 <include content="scrollbar_hor">
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1651"/>
                 </include>
             </control>

--- a/1080i/View_510_Minimal.xml
+++ b/1080i/View_510_Minimal.xml
@@ -236,7 +236,7 @@
                 </control>
             </control>
             <control type="scrollbar" id="1651">
-                <bottom>200</bottom>
+                <bottom>162</bottom>
                 <include content="scrollbar_hor">
                     <param name="scrollid" value="1651"/>
                 </include>

--- a/1080i/View_520_Minimal.xml
+++ b/1080i/View_520_Minimal.xml
@@ -242,8 +242,9 @@
                 </control>
             </control>
             <control type="scrollbar" id="1658">
-            <bottom>162</bottom>
+                <bottom>162</bottom>
                 <include content="scrollbar_hor">
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1658"/>
                 </include>
             </control>

--- a/1080i/View_520_Minimal.xml
+++ b/1080i/View_520_Minimal.xml
@@ -242,7 +242,7 @@
                 </control>
             </control>
             <control type="scrollbar" id="1658">
-                <bottom>200</bottom>
+            <bottom>162</bottom>
                 <include content="scrollbar_hor">
                     <param name="scrollid" value="1658"/>
                 </include>

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1962,6 +1962,10 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr ""
 
+msgctxt "#37805"
+msgid "Show scrollbar"
+msgstr ""
+
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr ""

--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -1962,10 +1962,6 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr ""
 
-msgctxt "#37805"
-msgid "Wrap list"
-msgstr ""
-
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr ""

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -1828,6 +1828,10 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr ""
 
+msgctxt "#37805"
+msgid "Show scrollbar"
+msgstr ""
+
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "In den Vollbildmodus wechseln, sobald Musik abgespielt wird"

--- a/language/German/strings.po
+++ b/language/German/strings.po
@@ -1828,10 +1828,6 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr ""
 
-msgctxt "#37805"
-msgid "Wrap list"
-msgstr "Umbruchsliste"
-
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "In den Vollbildmodus wechseln, sobald Musik abgespielt wird"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -1962,10 +1962,6 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr "녹화 라벨 아이콘"
 
-msgctxt "#37805"
-msgid "Wrap list"
-msgstr "포장 목록"
-
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "음악 재생이 시작되면 전체 화면 모드로 전환"

--- a/language/Korean/strings.po
+++ b/language/Korean/strings.po
@@ -1962,6 +1962,10 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr "녹화 라벨 아이콘"
 
+msgctxt "#37805"
+msgid "Show scrollbar"
+msgstr ""
+
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "음악 재생이 시작되면 전체 화면 모드로 전환"

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -1962,6 +1962,10 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr "Iconos de sello discográfico"
 
+msgctxt "#37805"
+msgid "Show scrollbar"
+msgstr ""
+
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "Cambiar a modo pantalla completa cuando la música comience a reproducirse"

--- a/language/Spanish/strings.po
+++ b/language/Spanish/strings.po
@@ -1962,10 +1962,6 @@ msgctxt "#37804"
 msgid "Record Label Icons"
 msgstr "Iconos de sello discográfico"
 
-msgctxt "#37805"
-msgid "Wrap list"
-msgstr "Lista enrollada"
-
 msgctxt "#37806"
 msgid "Switch to full screen mode when music starts playing"
 msgstr "Cambiar a modo pantalla completa cuando la música comience a reproducirse"

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -234,7 +234,7 @@
     
     <!-- Widget List Type? -->
     <propertySettings property="widgetListType" buttonID="4191" title="$LOCALIZE[37791]"/>
-    <property property="widgetListType" label="$LOCALIZE[37805]">wraplist</property>
+    <property property="widgetListType" label="$LOCALIZE[31148]">wraplist</property>
     <property property="widgetListType" label="$LOCALIZE[37792]">list</property>
     <property property="widgetListType" label="$LOCALIZE[37793]">fixedlist</property>
     


### PR DESCRIPTION
- Small changes on the `scrollbar_hor` width, notice by the grid that looks more centralized with `1740`
    - But why not use 100% of the grid?
- When scrolling through Big-Flix, since we have a bigger highlight item, we should move down the scrollbar, I figured out `162` looks good
- Added a new option (only for 510 and 520) to hide the scrollbar during the scrolling event... The scroll still there but will not appear during the "auto scroll", you know?
    - I notice one duplicated language string `Wrap list` and I used the ID for this options. Is that fine?
    
What you think?
Im not sure if we should change the default behaviour (to dont show the scroll when scrolling) or just add a new option... But that is it for now :D 

**The old position**
![Screenshot 2021-02-07 at 13 00 47](https://user-images.githubusercontent.com/15933/107151543-0d3d6580-695b-11eb-817d-a284e4877286.png)

**The new position**
![Screenshot 2021-02-07 at 13 00 14](https://user-images.githubusercontent.com/15933/107151548-13334680-695b-11eb-8177-7349cd7f7dc7.png)
