### PR TITLE
[Widgets] Format duration time

### DIFF
--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -6578,6 +6578,7 @@
         <control type="grouplist">
             <orientation>vertical</orientation>
             <itemgap>0</itemgap>
+            
             <control type="grouplist">
                 <itemgap>0</itemgap>
                 <visible>String.IsEqual(Container($PARAM[id]).ListItem.DBType,tvshow)</visible>
@@ -6586,28 +6587,68 @@
                 <usecontrolcoords>true</usecontrolcoords>
                 <control type="label">
                     <include>MultiWidgetsSubLabelDefinition</include>
-                    <label>$INFO[Container($PARAM[id]).ListItem.Episode,, $LOCALIZE[20360]]</label>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Episode,, $LOCALIZE[20360]  •  ]</label>
                 </control>
                 <control type="label">
                     <include>MultiWidgetsSubLabelDefinition</include>
-                    <label>  •  </label>
-                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Episode)</visible>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Property(UnWatchedEpisodes),, $LOCALIZE[16101]  •  ]</label>
+                </control>
+                <control type="label" description="Duration">
+                    <include>MultiWidgetsSubLabelDefinition</include>
+                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)</visible>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),, $LOCALIZE[31102]]</label>
+                </control>
+                <control type="label" description="Duration">
+                    <include>MultiWidgetsSubLabelDefinition</include>
+                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
+                </control>
+                <control type="label" description="Duration">
+                    <include>MultiWidgetsSubLabelDefinition</include>
+                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),,$LOCALIZE[37616]]</label>
                 </control>
                 <control type="label">
                     <include>MultiWidgetsSubLabelDefinition</include>
-                    <label>$INFO[Container($PARAM[id]).ListItem.Property(UnWatchedEpisodes),, $LOCALIZE[16101]]$INFO[Container($PARAM[id]).ListItem.Duration(mins),  •  , $LOCALIZE[31102]]$INFO[Container($PARAM[id]).ListItem.Rating,  •  ]$VAR[RtMclabel]</label>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Rating,  •  ]$VAR[RtMclabel]</label>
                 </control>
             </control>
-            <control type="label">
-                <include>MultiWidgetsSubLabelDefinition</include>
-                <label>$INFO[Container($PARAM[id]).ListItem.Year,,  •  ]$INFO[Container($PARAM[id]).ListItem.Duration(mins),, $LOCALIZE[31102]]$INFO[Container($PARAM[id]).ListItem.Rating,  •  ]$VAR[RtMclabel]</label>
-                <visible>String.IsEqual(Container($PARAM[id]).ListItem.DBType,movie) | String.IsEqual(Container($PARAM[id]).ListItem.DBType,episode)</visible>
+
+            <control type="grouplist">
+              <itemgap>0</itemgap>
+              <visible>String.IsEqual(Container($PARAM[id]).ListItem.DBType,movie) | String.IsEqual(Container($PARAM[id]).ListItem.DBType,episode)</visible>
+              <orientation>horizontal</orientation>
+              <control type="label">
+                  <include>MultiWidgetsSubLabelDefinition</include>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Year,,  •  ]</label>
+              </control>
+              <control type="label" description="Duration">
+                  <include>MultiWidgetsSubLabelDefinition</include>
+                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)</visible>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),, $LOCALIZE[31102]]</label>
+              </control>
+              <control type="label" description="Duration">
+                  <include>MultiWidgetsSubLabelDefinition</include>
+                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
+              </control>
+              <control type="label" description="Duration">
+                  <include>MultiWidgetsSubLabelDefinition</include>
+                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),,$LOCALIZE[37616]]</label>
+              </control>
+              <control type="label">
+                  <include>MultiWidgetsSubLabelDefinition</include>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Rating,  •  ]$VAR[RtMclabel]</label>
+              </control>
             </control>
+
             <control type="label">
                 <include>MultiWidgetsSubLabelDefinition</include>
                 <label>$INFO[Container($PARAM[id]).ListItem.Year]$INFO[Container($PARAM[id]).ListItem.Rating,  •  ] $INFO[Control.GetLabel(9966)]</label>
                 <visible>String.IsEqual(Container($PARAM[id]).ListItem.DBType,set)</visible>
             </control>
+
             <control type="grouplist">
                 <itemgap>0</itemgap>
                 <visible>String.IsEqual(Container($PARAM[id]).ListItem.DBType,album)</visible>

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -6600,13 +6600,18 @@
                 </control>
                 <control type="label" description="Duration">
                     <include>MultiWidgetsSubLabelDefinition</include>
-                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(m),0)</visible>
                     <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
                 </control>
                 <control type="label" description="Duration">
                     <include>MultiWidgetsSubLabelDefinition</include>
+                    <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(m),0)</visible>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]]</label>
+                </control>
+                <control type="label" description="Duration">
+                    <include>MultiWidgetsSubLabelDefinition</include>
                     <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
-                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),,$LOCALIZE[37616]]</label>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
                 </control>
                 <control type="label">
                     <include>MultiWidgetsSubLabelDefinition</include>
@@ -6629,13 +6634,18 @@
               </control>
               <control type="label" description="Duration">
                   <include>MultiWidgetsSubLabelDefinition</include>
-                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
+                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(m),0)</visible>
                   <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
               </control>
               <control type="label" description="Duration">
                   <include>MultiWidgetsSubLabelDefinition</include>
+                  <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(m),0)</visible>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(h),,$LOCALIZE[37615]]</label>
+              </control>
+              <control type="label" description="Duration">
+                  <include>MultiWidgetsSubLabelDefinition</include>
                   <visible>!String.IsEmpty(Container($PARAM[id]).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container($PARAM[id]).ListItem.Duration(h),0)</visible>
-                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(mins),,$LOCALIZE[37616]]</label>
+                  <label>$INFO[Container($PARAM[id]).ListItem.Duration(m),,$LOCALIZE[37616]]</label>
               </control>
               <control type="label">
                   <include>MultiWidgetsSubLabelDefinition</include>

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -364,32 +364,37 @@
 
     <variable name="LabelDurationTimeCheck55">
         <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)">$INFO[Container(55).ListItem.Duration(mins),, $LOCALIZE[31102]]</value>
-        <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(55).ListItem.Duration(h),0)">$INFO[Container(55).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(55).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
-        <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(55).ListItem.Duration(h),0)">$INFO[Container(55).ListItem.Duration(mins),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(55).ListItem.Duration(h),0) + Integer.IsGreater(Container(55).ListItem.Duration(m),0)">$INFO[Container(55).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(55).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(55).ListItem.Duration(h),0) + !Integer.IsGreater(Container(55).ListItem.Duration(m),0)">$INFO[Container(55).ListItem.Duration(h),,$LOCALIZE[37615]]</value>
+        <value condition="!String.IsEmpty(Container(55).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(55).ListItem.Duration(h),0)">$INFO[Container(55).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
     </variable>
 
     <variable name="LabelDurationTimeCheck301">
         <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)">$INFO[Container(301).ListItem.Duration(mins),, $LOCALIZE[31102]]</value>
-        <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(301).ListItem.Duration(h),0)">$INFO[Container(301).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(301).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
-        <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(301).ListItem.Duration(h),0)">$INFO[Container(301).ListItem.Duration(mins),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(301).ListItem.Duration(h),0) + Integer.IsGreater(Container(301).ListItem.Duration(m),0)">$INFO[Container(301).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(301).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(301).ListItem.Duration(h),0) + !Integer.IsGreater(Container(301).ListItem.Duration(m),0)">$INFO[Container(301).ListItem.Duration(h),,$LOCALIZE[37615]]</value>
+        <value condition="!String.IsEmpty(Container(301).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(301).ListItem.Duration(h),0)">$INFO[Container(301).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
     </variable>
 
     <variable name="LabelDurationTimeCheck9500">
         <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)">$INFO[Container(9500).ListItem.Duration(mins),, $LOCALIZE[31102]]</value>
-        <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(9500).ListItem.Duration(h),0)">$INFO[Container(9500).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(9500).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
-        <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(9500).ListItem.Duration(h),0)">$INFO[Container(9500).ListItem.Duration(mins),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(9500).ListItem.Duration(h),0) + Integer.IsGreater(Container(9500).ListItem.Duration(m),0)">$INFO[Container(9500).ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[Container(9500).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(Container(9500).ListItem.Duration(h),0) + !Integer.IsGreater(Container(9500).ListItem.Duration(m),0)">$INFO[Container(9500).ListItem.Duration(h),,$LOCALIZE[37615]]</value>
+        <value condition="!String.IsEmpty(Container(9500).ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(Container(9500).ListItem.Duration(h),0)">$INFO[Container(9500).ListItem.Duration(m),,$LOCALIZE[37616]]</value>
     </variable>
 
     <variable name="LabelDurationTimeCheck">
         <value condition="!String.IsEmpty(ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)">$INFO[ListItem.Duration(mins),, $LOCALIZE[31102]]</value>
-        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
-        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(mins),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0) + Integer.IsGreater(ListItem.Duration(m),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0) + !Integer.IsGreater(ListItem.Duration(m),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
     </variable>
 
     <variable name="LabelDurationTimeCheckInfo">
         <value condition="!String.IsEmpty(ListItem.Duration(mins)) + !Skin.HasSetting(NewTime)">$INFO[ListItem.Duration(mins),, $LOCALIZE[12391]]</value>
-        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
-        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(mins),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0) + Integer.IsGreater(ListItem.Duration(m),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]] $INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + Integer.IsGreater(ListItem.Duration(h),0) + !Integer.IsGreater(ListItem.Duration(m),0)">$INFO[ListItem.Duration(h),,$LOCALIZE[37615]]</value>
+        <value condition="!String.IsEmpty(ListItem.Duration(mins)) + Skin.HasSetting(NewTime) + !Integer.IsGreater(ListItem.Duration(h),0)">$INFO[ListItem.Duration(m),,$LOCALIZE[37616]]</value>
         <value condition="ListItem.IsCollection + !String.IsEmpty(Window(home).Property(SkinInfo.Set.Movies.Runtime))">$INFO[Window(home).Property(SkinInfo.Set.Movies.Runtime),, $LOCALIZE[12391]]</value>
     </variable>
     


### PR DESCRIPTION
I notice some home widgets are not formatted to "new time"

Because those widgets are using `$PARAM[id]` to determine `Container.ListItem`, I could only duplicate the code...
I was not able to use the the same variable `LabelDurationTimeCheck` from "Includes_Labels.xml"...
Maybe you have some ideia to improve that avoiding duplicate code

**New Time format disabled**
![Screenshot 2021-02-14 at 14 00 10](https://user-images.githubusercontent.com/15933/107878973-0e781080-6ece-11eb-8ea4-de855917b9e9.png)


**New Time format enable**
![Screenshot 2021-02-14 at 13 59 51](https://user-images.githubusercontent.com/15933/107878974-120b9780-6ece-11eb-9870-8f410f2d8bc8.png)
