### PR TITLE
[AudioCodec] Add opus flag

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -914,6 +914,7 @@
         <value condition="String.Contains(ListItem.Filenameandpath,.dts-x-)">dts-x</value>
         <value condition="String.Contains(ListItem.Filenameandpath,.dts.x-)">dts-x</value>
         <value condition="String.Contains(ListItem.Filenameandpath,.dtsx-)">dts-x</value>
+        <value condition="String.Contains(ListItem.Filenameandpath,.opus.)">opus</value>
         <value>$INFO[ListItem.AudioCodec]</value>
     </variable>
 
@@ -926,6 +927,7 @@
         <value condition="String.Contains(Player.Filename,.dts-x-)">dts-x</value>
         <value condition="String.Contains(Player.Filename,.dts.x-)">dts-x</value>
         <value condition="String.Contains(Player.Filename,.dtsx-)">dts-x</value>
+        <value condition="String.Contains(Player.Filename,.opus.)">opus</value>
         <value>$INFO[VideoPlayer.AudioCodec]</value>
     </variable>
 


### PR DESCRIPTION
Recently I got some subs in x265 that are using [opus](https://en.wikipedia.org/wiki/Opus_(audio_format)) codec and the theme was showing just `???` for that.

I dont know how usually that codec are (maybe is rare) but I dont like to see `???`...

I add 3 files to `Texture.xbt` (using windows texture tool)

`flags/audio/opus.png` 
![opus](https://user-images.githubusercontent.com/15933/108789729-cc586a00-7572-11eb-8685-640a4773d966.png)

`flags3/audio/opus.png`
![opus](https://user-images.githubusercontent.com/15933/108789729-cc586a00-7572-11eb-8685-640a4773d966.png)

`flags/color/audio/opus.png`
![opus](https://user-images.githubusercontent.com/15933/108789739-d0848780-7572-11eb-956e-f1fc129de328.png)

**The result**
![Screenshot 2021-02-23 at 01 04 31](https://user-images.githubusercontent.com/15933/108789870-2b1de380-7573-11eb-98b9-6684a07289aa.png)
![Screenshot 2021-02-23 at 01 04 44](https://user-images.githubusercontent.com/15933/108789873-2bb67a00-7573-11eb-970e-6b7e424315f2.png)

