### PR TITLE
[Flags] Fix HDR condition

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -950,26 +950,18 @@
     </variable>
 
     <variable name="LabelOSDhdr">
-        <value condition="String.Contains(Player.Filenameandpath,.hdr10plus.) | String.Contains(Player.Filenameandpath,hdr10plus)">hdr10+</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hdr10.) | String.Contains(Player.Filenameandpath,hdr10)">hdr10</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hdr.) | String.Contains(Player.Filenameandpath,hdr)">hdr</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hlg.) | String.Contains(Player.Filenameandpath,hlg)">hlg</value>
+        <value condition="String.Contains(Player.Filenameandpath,.hdr10plus.)">hdr10+</value>
+        <value condition="String.Contains(Player.Filenameandpath,.hdr10.)">hdr10</value>
+        <value condition="String.Contains(Player.Filenameandpath,.hdr.)">hdr</value>
+        <value condition="String.Contains(Player.Filenameandpath,.hlg.)">hlg</value>
         <value condition="String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision)">dolby vision</value>
     </variable>
 
     <variable name="LabelFurniturehdr">
         <value condition="String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr10plus.)">hdr10+</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,hdr10plus) | String.Contains(Container(9500).ListItem.Filenameandpath,hdr10plus)">hdr10+</value>
-        
         <value condition="String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr10.)">hdr10</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,hdr10) | String.Contains(Container(9500).ListItem.Filenameandpath,hdr10)">hdr10</value>
-
         <value condition="String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr.)">hdr</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,hdr) | String.Contains(Container(9500).ListItem.Filenameandpath,hdr)">hdr</value>
-
         <value condition="String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hlg.)">hlg</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,hlg) | String.Contains(Container(9500).ListItem.Filenameandpath,hlg)">hlg</value>
-        
         <value condition="String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(Container(9500).ListItem.Filenameandpath,.dv.)">dolby vision</value>
         <value condition="String.Contains(ListItem.Filenameandpath,dolbyvision) | String.Contains(Container(9500).ListItem.Filenameandpath,dolbyvision)">dolby vision</value>
     </variable>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -641,7 +641,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(ListItem.Filenameandpath,hdr10plus)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -649,7 +649,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(ListItem.Filenameandpath,hdr10)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -657,7 +657,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="80">auto</width>
@@ -665,7 +665,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(ListItem.Filenameandpath,hlg)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1060,7 +1060,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(ListItem.Filenameandpath,hdr10plus)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1069,7 +1069,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(ListItem.Filenameandpath,hdr10)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1078,7 +1078,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="80">auto</width>
@@ -1087,7 +1087,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(ListItem.Filenameandpath,hlg)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1487,7 +1487,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(ListItem.Filenameandpath,hdr10plus)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="130">auto</width>
@@ -1495,7 +1495,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(ListItem.Filenameandpath,hdr10)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -1503,7 +1503,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="80">auto</width>
@@ -1511,7 +1511,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(ListItem.Filenameandpath,hlg)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="130">auto</width>
@@ -1911,7 +1911,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(ListItem.Filenameandpath,hdr10plus)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -1920,7 +1920,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(ListItem.Filenameandpath,hdr10)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -1929,7 +1929,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(ListItem.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="80">auto</width>
@@ -1938,7 +1938,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(ListItem.Filenameandpath,hlg)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -244,7 +244,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filename,.hdr10plus.) | String.Contains(Player.Filename,hdr10plus)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr10plus.)</visible>
                 </control>
                 <control type="image" description="HDR10">
                     <width min="20" max="100">auto</width>
@@ -252,7 +252,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filename,.hdr10.) | String.Contains(Player.Filename,hdr10]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr10.)</visible>
                 </control>
                 <control type="image" description="HDR">
                     <width min="20" max="100">auto</width>
@@ -260,7 +260,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filename,.hdr.) | String.Contains(Player.Filename,hdr)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr.)</visible>
                 </control>
                 <control type="image"  description="HLG">
                     <width min="20" max="100">auto</width>
@@ -268,7 +268,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filename,.hlg.) | String.Contains(Player.Filename,hlg)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hlg.)</visible>
                 </control>
                 <control type="image"  description="Dolby Vision">
                     <width min="20" max="100">auto</width>
@@ -346,7 +346,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10plus.) | String.Contains(Player.Filenameandpath,hdr10plus)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
                 </control>
                 <control type="image" description="HDR10">
                     <width min="20" max="100">auto</width>
@@ -354,7 +354,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10.) | String.Contains(Player.Filenameandpath,hdr10)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
                 </control>
                 <control type="image" description="HDR">
                     <width min="20" max="100">auto</width>
@@ -362,7 +362,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr.) | String.Contains(Player.Filenameandpath,hdr)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
                 </control>
                 <control type="image" description="HLG">
                     <width min="20" max="100">auto</width>
@@ -370,7 +370,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hlg.) | String.Contains(Player.Filenameandpath,hlg)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
                 </control>
                 <control type="image" description="Dolby Vision">
                     <width min="20" max="100">auto</width>
@@ -645,7 +645,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10plus.) | String.Contains(Player.Filenameandpath,hdr10plus)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -653,7 +653,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10.) | String.Contains(Player.Filenameandpath,hdr10)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -661,7 +661,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr.) | String.Contains(Player.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="100">auto</width>
@@ -669,7 +669,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hlg.) | String.Contains(Player.Filenameandpath,hlg)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>
@@ -783,7 +783,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10plus.) | String.Contains(Player.Filenameandpath,hdr10plus)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -791,7 +791,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr10.) | String.Contains(Player.Filenameandpath,hdr10)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -799,7 +799,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hdr.) | String.Contains(Player.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="100">auto</width>
@@ -807,7 +807,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.hlg.) | String.Contains(Player.Filenameandpath,hlg)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>


### PR DESCRIPTION
I thought I had test this case, but looks like not...

The thing is, we can not test the string `hdr` without the comma as limiter (before and after), otherwise we will always have missmatching, like contains `.hdr` or `hdr` will both be true for `.hdr10` and `.hdr10plus`, the same for `.hdr10` to `.hdr10plus` etc... 

Lets be more restrictive and set only the comma as limiter (at least for HDR)... what do you think? Is it fine?