### PR TITLE
Use expression for audiocodec and hdr detection

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -68,16 +68,36 @@
     <expression name="Widget5Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.5),yes)</expression>
     <expression name="Widget6Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.6),yes)</expression>
     <expression name="IsAudioCodecATMOS">
-      String.Contains(ListItem.Filenameandpath,.atmos.) | String.Contains(ListItem.Filenameandpath,.atmos-)
-      | String.Contains(Player.Filenameandpath,.atmos.) | String.Contains(Player.Filenameandpath,.atmos-)
+        String.Contains(ListItem.Filenameandpath,.atmos.) | String.Contains(ListItem.Filenameandpath,.atmos-)
+        | String.Contains(Player.Filenameandpath,.atmos.) | String.Contains(Player.Filenameandpath,.atmos-)
     </expression>
     <expression name="IsAudioCodecDTSX">
-      String.Contains(ListItem.Filenameandpath,.dts-x.) | String.Contains(ListItem.Filenameandpath,.dts.x.) | String.Contains(ListItem.Filenameandpath,.dtsx.) | String.Contains(ListItem.Filenameandpath,.dts-x-) | String.Contains(ListItem.Filenameandpath,.dts.x-) | String.Contains(ListItem.Filenameandpath,.dtsx-)
-      | String.Contains(Player.Filenameandpath,.dts-x.) | String.Contains(Player.Filenameandpath,.dts.x.) | String.Contains(Player.Filenameandpath,.dtsx.) | String.Contains(Player.Filenameandpath,.dts-x-) | String.Contains(Player.Filenameandpath,.dts.x-) | String.Contains(Player.Filenameandpath,.dtsx-)
+        String.Contains(ListItem.Filenameandpath,.dts-x.) | String.Contains(ListItem.Filenameandpath,.dts.x.) | String.Contains(ListItem.Filenameandpath,.dtsx.) | String.Contains(ListItem.Filenameandpath,.dts-x-) | String.Contains(ListItem.Filenameandpath,.dts.x-) | String.Contains(ListItem.Filenameandpath,.dtsx-)
+        | String.Contains(Player.Filenameandpath,.dts-x.) | String.Contains(Player.Filenameandpath,.dts.x.) | String.Contains(Player.Filenameandpath,.dtsx.) | String.Contains(Player.Filenameandpath,.dts-x-) | String.Contains(Player.Filenameandpath,.dts.x-) | String.Contains(Player.Filenameandpath,.dtsx-)
     </expression>
     <expression name="IsAudioCodecOPUS">
-      String.Contains(ListItem.Filenameandpath,.opus.)
-      | String.Contains(Player.Filenameandpath,.opus.)
+        String.Contains(ListItem.Filenameandpath,.opus.)
+        | String.Contains(Player.Filenameandpath,.opus.)
+    </expression>
+    <expression name="IsVideoHDR10Plus">
+        String.Contains(ListItem.Filenameandpath,.hdr10plus.)
+        | String.Contains(Player.Filenameandpath,.hdr10plus.)
+    </expression>
+    <expression name="IsVideoHDR10">
+        String.Contains(ListItem.Filenameandpath,.hdr10.)
+        | String.Contains(Player.Filenameandpath,.hdr10.)
+    </expression>
+    <expression name="IsVideoHDR">
+        String.Contains(ListItem.Filenameandpath,.hdr.)
+        | String.Contains(Player.Filenameandpath,.hdr.)
+    </expression>
+    <expression name="IsVideoHLG">
+        String.Contains(ListItem.Filenameandpath,.hlg.)
+        | String.Contains(Player.Filenameandpath,.hlg.)
+    </expression>
+    <expression name="IsVideoDolbyVision">
+        String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision) | String.Contains(ListItem.Filenameandpath,dolby-vision)
+        | String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision) | String.Contains(Player.Filenameandpath,dolby-vision)
     </expression>
 
     <include name="ScrolltimeDetailsList">
@@ -943,21 +963,12 @@
         <value condition="!String.IsEmpty(VideoPlayer.AudioCodec)">$INFO[VideoPlayer.AudioCodec]</value>
     </variable>
 
-    <variable name="LabelOSDhdr">
-        <value condition="String.Contains(Player.Filenameandpath,.hdr10plus.)">hdr10+</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hdr10.)">hdr10</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hdr.)">hdr</value>
-        <value condition="String.Contains(Player.Filenameandpath,.hlg.)">hlg</value>
-        <value condition="String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision)">dolby vision</value>
-    </variable>
-
-    <variable name="LabelFurniturehdr">
-        <value condition="String.Contains(ListItem.Filenameandpath,.hdr10plus.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr10plus.)">hdr10+</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.hdr10.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr10.)">hdr10</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.hdr.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hdr.)">hdr</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.hlg.) | String.Contains(Container(9500).ListItem.Filenameandpath,.hlg.)">hlg</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(Container(9500).ListItem.Filenameandpath,.dv.)">dolby vision</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,dolbyvision) | String.Contains(Container(9500).ListItem.Filenameandpath,dolbyvision)">dolby vision</value>
+    <variable name="ListItemHDR">
+        <value condition="$EXP[IsVideoHDR10Plus]">hdr10+</value>
+        <value condition="$EXP[IsVideoHDR10]">hdr10</value>
+        <value condition="$EXP[IsVideoHDR]">hdr</value>
+        <value condition="$EXP[IsVideoHLG]">hlg</value>
+        <value condition="$EXP[IsVideoDolbyVision]">dolby vision</value>
     </variable>
 
     <include name="weatherlist">

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -67,6 +67,18 @@
     <expression name="Widget4Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.4),yes)</expression>
     <expression name="Widget5Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.5),yes)</expression>
     <expression name="Widget6Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.6),yes)</expression>
+    <expression name="IsAudioCodecATMOS">
+      String.Contains(ListItem.Filenameandpath,.atmos.) | String.Contains(ListItem.Filenameandpath,.atmos-)
+      | String.Contains(Player.Filenameandpath,.atmos.) | String.Contains(Player.Filenameandpath,.atmos-)
+    </expression>
+    <expression name="IsAudioCodecDTSX">
+      String.Contains(ListItem.Filenameandpath,.dts-x.) | String.Contains(ListItem.Filenameandpath,.dts.x.) | String.Contains(ListItem.Filenameandpath,.dtsx.) | String.Contains(ListItem.Filenameandpath,.dts-x-) | String.Contains(ListItem.Filenameandpath,.dts.x-) | String.Contains(ListItem.Filenameandpath,.dtsx-)
+      | String.Contains(Player.Filenameandpath,.dts-x.) | String.Contains(Player.Filenameandpath,.dts.x.) | String.Contains(Player.Filenameandpath,.dtsx.) | String.Contains(Player.Filenameandpath,.dts-x-) | String.Contains(Player.Filenameandpath,.dts.x-) | String.Contains(Player.Filenameandpath,.dtsx-)
+    </expression>
+    <expression name="IsAudioCodecOPUS">
+      String.Contains(ListItem.Filenameandpath,.opus.)
+      | String.Contains(Player.Filenameandpath,.opus.)
+    </expression>
 
     <include name="ScrolltimeDetailsList">
         <scrolltime tween="sine" easing="inout">250</scrolltime>
@@ -924,29 +936,11 @@
     </include>
 
     <variable name="ListItemAudioCodec">
-        <value condition="String.Contains(ListItem.Filenameandpath,.atmos.)">atmos</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.atmos-)">atmos</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dts-x.)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dts.x.)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dtsx.)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dts-x-)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dts.x-)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.dtsx-)">dts-x</value>
-        <value condition="String.Contains(ListItem.Filenameandpath,.opus.)">opus</value>
-        <value>$INFO[ListItem.AudioCodec]</value>
-    </variable>
-
-    <variable name="ListItemAudioCodecPlayer">
-        <value condition="String.Contains(Player.Filename,.atmos.)">atmos</value>
-        <value condition="String.Contains(Player.Filename,.atmos-)">atmos</value>
-        <value condition="String.Contains(Player.Filename,.dts-x.)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.dts.x.)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.dtsx.)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.dts-x-)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.dts.x-)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.dtsx-)">dts-x</value>
-        <value condition="String.Contains(Player.Filename,.opus.)">opus</value>
-        <value>$INFO[VideoPlayer.AudioCodec]</value>
+        <value condition="$EXP[IsAudioCodecATMOS]">atmos</value>
+        <value condition="$EXP[IsAudioCodecDTSX]">dts-x</value>
+        <value condition="$EXP[IsAudioCodecOPUS]">opus</value>
+        <value condition="!String.IsEmpty(ListItem.AudioCodec)">$INFO[ListItem.AudioCodec]</value>
+        <value condition="!String.IsEmpty(VideoPlayer.AudioCodec)">$INFO[VideoPlayer.AudioCodec]</value>
     </variable>
 
     <variable name="LabelOSDhdr">

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -68,32 +68,32 @@
     <expression name="Widget5Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.5),yes)</expression>
     <expression name="Widget6Enabled">String.Contains(Container(300).ListItem.Property(widgetEnable.6),yes)</expression>
     <expression name="IsAudioCodecATMOS">
-        String.Contains(ListItem.Filenameandpath,.atmos.) | String.Contains(ListItem.Filenameandpath,.atmos-)
-        | String.Contains(Player.Filenameandpath,.atmos.) | String.Contains(Player.Filenameandpath,.atmos-)
+        String.Contains(ListItem.FileNameAndPath,.atmos.) | String.Contains(ListItem.FileNameAndPath,.atmos-)
+        | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.atmos.) | String.Contains(Player.FileNameAndPath,.atmos-)]]
     </expression>
     <expression name="IsAudioCodecDTSX">
-        String.Contains(ListItem.Filenameandpath,.dts-x.) | String.Contains(ListItem.Filenameandpath,.dts.x.) | String.Contains(ListItem.Filenameandpath,.dtsx.) | String.Contains(ListItem.Filenameandpath,.dts-x-) | String.Contains(ListItem.Filenameandpath,.dts.x-) | String.Contains(ListItem.Filenameandpath,.dtsx-)
-        | String.Contains(Player.Filenameandpath,.dts-x.) | String.Contains(Player.Filenameandpath,.dts.x.) | String.Contains(Player.Filenameandpath,.dtsx.) | String.Contains(Player.Filenameandpath,.dts-x-) | String.Contains(Player.Filenameandpath,.dts.x-) | String.Contains(Player.Filenameandpath,.dtsx-)
+        String.Contains(ListItem.FileNameAndPath,.dts-x.) | String.Contains(ListItem.FileNameAndPath,.dts.x.) | String.Contains(ListItem.FileNameAndPath,.dtsx.) | String.Contains(ListItem.FileNameAndPath,.dts-x-) | String.Contains(ListItem.FileNameAndPath,.dts.x-) | String.Contains(ListItem.FileNameAndPath,.dtsx-)
+        | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.dts-x.) | String.Contains(Player.FileNameAndPath,.dts.x.) | String.Contains(Player.FileNameAndPath,.dtsx.) | String.Contains(Player.FileNameAndPath,.dts-x-) | String.Contains(Player.FileNameAndPath,.dts.x-) | String.Contains(Player.FileNameAndPath,.dtsx-)]]
     </expression>
     <expression name="IsVideoHDR10Plus">
-        String.Contains(ListItem.Filenameandpath,.hdr10plus.)
-        | String.Contains(Player.Filenameandpath,.hdr10plus.)
+        String.Contains(ListItem.FileNameAndPath,.hdr10plus.)
+        | [VideoPlayer.IsFullscreen + String.Contains(Player.FileNameAndPath,.hdr10plus.)]
     </expression>
     <expression name="IsVideoHDR10">
-        String.Contains(ListItem.Filenameandpath,.hdr10.)
-        | String.Contains(Player.Filenameandpath,.hdr10.)
+        String.Contains(ListItem.FileNameAndPath,.hdr10.)
+        | [VideoPlayer.IsFullscreen + String.Contains(Player.FileNameAndPath,.hdr10.)]
     </expression>
     <expression name="IsVideoHDR">
-        String.Contains(ListItem.Filenameandpath,.hdr.)
-        | String.Contains(Player.Filenameandpath,.hdr.)
+        String.Contains(ListItem.FileNameAndPath,.hdr.)
+        | [VideoPlayer.IsFullscreen + String.Contains(Player.FileNameAndPath,.hdr.)]
     </expression>
     <expression name="IsVideoHLG">
-        String.Contains(ListItem.Filenameandpath,.hlg.)
-        | String.Contains(Player.Filenameandpath,.hlg.)
+        String.Contains(ListItem.FileNameAndPath,.hlg.)
+        | [VideoPlayer.IsFullscreen + String.Contains(Player.FileNameAndPath,.hlg.)]
     </expression>
     <expression name="IsVideoDolbyVision">
-        String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision) | String.Contains(ListItem.Filenameandpath,dolby-vision)
-        | String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision) | String.Contains(Player.Filenameandpath,dolby-vision)
+        String.Contains(ListItem.FileNameAndPath,.dv.) | String.Contains(ListItem.FileNameAndPath,dolbyvision) | String.Contains(ListItem.FileNameAndPath,dolby-vision)
+        | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.dv.) | String.Contains(Player.FileNameAndPath,dolbyvision) | String.Contains(Player.FileNameAndPath,dolby-vision)]]
     </expression>
 
     <include name="ScrolltimeDetailsList">
@@ -954,8 +954,8 @@
     <variable name="ListItemAudioCodec">
         <value condition="$EXP[IsAudioCodecATMOS]">atmos</value>
         <value condition="$EXP[IsAudioCodecDTSX]">dts-x</value>
-        <value condition="!String.IsEmpty(ListItem.AudioCodec)">$INFO[ListItem.AudioCodec]</value>
-        <value condition="!String.IsEmpty(VideoPlayer.AudioCodec)">$INFO[VideoPlayer.AudioCodec]</value>
+        <value condition="VideoPlayer.IsFullscreen">$INFO[VideoPlayer.AudioCodec]</value>
+        <value>$INFO[ListItem.AudioCodec]</value>
     </variable>
 
     <variable name="ListItemHDR">
@@ -1501,11 +1501,11 @@
             </control>
             
             <control type="radiobutton" id="9077">
-                <visible>String.IsEqual(ListItem.DBType,tvshow) + Integer.IsGreater(ListItem.Property(UnwatchedEpisodes),0) + !String.IsEmpty(ListItem.DBID) + !Skin.HasSetting(HideNextUpEpisodeButton) + !String.IsEmpty(Container(9911).ListItem.Filenameandpath)</visible>
+                <visible>String.IsEqual(ListItem.DBType,tvshow) + Integer.IsGreater(ListItem.Property(UnwatchedEpisodes),0) + !String.IsEmpty(ListItem.DBID) + !Skin.HasSetting(HideNextUpEpisodeButton) + !String.IsEmpty(Container(9911).ListItem.FileNameAndPath)</visible>
                 <onfocus>ClearProperty(moviecontent)</onfocus>
                 <onfocus>ClearProperty(ShowDisc)</onfocus>
                 <onclick>Dialog.Close(all)</onclick>
-                <onclick>PlayMedia($ESCINFO[Container(9911).ListItem.Filenameandpath])</onclick>
+                <onclick>PlayMedia($ESCINFO[Container(9911).ListItem.FileNameAndPath])</onclick>
                 <include>buttondimensions</include>
                 <include content="buttontextures">
                     <param name="icon" value="buttonsdialogs/upnext.png"/>

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -75,10 +75,6 @@
         String.Contains(ListItem.Filenameandpath,.dts-x.) | String.Contains(ListItem.Filenameandpath,.dts.x.) | String.Contains(ListItem.Filenameandpath,.dtsx.) | String.Contains(ListItem.Filenameandpath,.dts-x-) | String.Contains(ListItem.Filenameandpath,.dts.x-) | String.Contains(ListItem.Filenameandpath,.dtsx-)
         | String.Contains(Player.Filenameandpath,.dts-x.) | String.Contains(Player.Filenameandpath,.dts.x.) | String.Contains(Player.Filenameandpath,.dtsx.) | String.Contains(Player.Filenameandpath,.dts-x-) | String.Contains(Player.Filenameandpath,.dts.x-) | String.Contains(Player.Filenameandpath,.dtsx-)
     </expression>
-    <expression name="IsAudioCodecOPUS">
-        String.Contains(ListItem.Filenameandpath,.opus.)
-        | String.Contains(Player.Filenameandpath,.opus.)
-    </expression>
     <expression name="IsVideoHDR10Plus">
         String.Contains(ListItem.Filenameandpath,.hdr10plus.)
         | String.Contains(Player.Filenameandpath,.hdr10plus.)
@@ -958,7 +954,6 @@
     <variable name="ListItemAudioCodec">
         <value condition="$EXP[IsAudioCodecATMOS]">atmos</value>
         <value condition="$EXP[IsAudioCodecDTSX]">dts-x</value>
-        <value condition="$EXP[IsAudioCodecOPUS]">opus</value>
         <value condition="!String.IsEmpty(ListItem.AudioCodec)">$INFO[ListItem.AudioCodec]</value>
         <value condition="!String.IsEmpty(VideoPlayer.AudioCodec)">$INFO[VideoPlayer.AudioCodec]</value>
     </variable>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -610,7 +610,7 @@
                     <height>64</height>
                     <align>left</align>
                     <aligny>center</aligny>
-                    <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                    <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                     <font>Flag</font>
                     <textcolor>Dark1</textcolor>
                     <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
@@ -641,7 +641,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR10Plus]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -649,7 +649,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR10]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -657,7 +657,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="80">auto</width>
@@ -665,7 +665,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHLG]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -673,7 +673,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/dolbyvision.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoDolbyVision]</visible>
                 </control>
 
                 <control type="image">
@@ -1028,7 +1028,7 @@
                     <height>64</height>
                     <align>left</align>
                     <aligny>center</aligny>
-                    <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                    <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                     <font>Flag</font>
                     <textcolor>Dark1</textcolor>
                     <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
@@ -1060,7 +1060,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR10Plus]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1069,7 +1069,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR10]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1078,7 +1078,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="80">auto</width>
@@ -1087,7 +1087,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHLG]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1096,7 +1096,7 @@
                     <centertop>50%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/dolbyvision.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoDolbyVision]</visible>
                 </control>
 
                 <control type="image">
@@ -1456,7 +1456,7 @@
                 <height>64</height>
                 <align>left</align>
                 <aligny>center</aligny>
-                <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
@@ -1487,7 +1487,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR10Plus]</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="130">auto</width>
@@ -1495,7 +1495,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR10]</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -1503,7 +1503,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR]</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="80">auto</width>
@@ -1511,7 +1511,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHLG]</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="130">auto</width>
@@ -1519,7 +1519,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/dolbyvision.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoDolbyVision]</visible>
             </control>
 
             <control type="image" description="MPAA">
@@ -1879,7 +1879,7 @@
                 <height>64</height>
                 <align>left</align>
                 <aligny>center</aligny>
-                <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                <label>$INFO[ListItem.VideoCodec,,  •  ]$INFO[ListItem.VideoResolution]$INFO[ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(ListItem.VideoResolution)</visible>
@@ -1911,7 +1911,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10plus.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR10Plus]</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -1920,7 +1920,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr10.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR10]</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -1929,7 +1929,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hdr.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHDR]</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="80">auto</width>
@@ -1938,7 +1938,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + String.Contains(ListItem.Filenameandpath,.hlg.)</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoHLG]</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>
@@ -1947,7 +1947,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/dolbyvision.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + [String.Contains(ListItem.Filenameandpath,.dv.) | String.Contains(ListItem.Filenameandpath,dolbyvision)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + !Skin.HasSetting(furniture.flags.hdr) + $EXP[IsVideoDolbyVision]</visible>
             </control>
 
             <control type="image" description="MPAA">
@@ -2313,7 +2313,7 @@
                 <height>64</height>
                 <align>left</align>
                 <aligny>center</aligny>
-                <label>$INFO[Container(9500).ListItem.VideoCodec,,  •  ]$INFO[Container(9500).ListItem.VideoResolution]$INFO[Container(9500).ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                <label>$INFO[Container(9500).ListItem.VideoCodec,,  •  ]$INFO[Container(9500).ListItem.VideoResolution]$INFO[Container(9500).ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(Container(9500).ListItem.VideoResolution)</visible>
@@ -2341,7 +2341,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>String.Contains(Container(9500).ListItem.Filenameandpath,.hdr.) | String.Contains(Container(9500).ListItem.Filenameandpath,hdr)</visible>
+                <visible>$EXP[IsVideoHDR]</visible>
             </control>
             <control type="image">
                 <width min="20" max="100">auto</width>
@@ -2626,7 +2626,7 @@
                 <height>64</height>
                 <align>left</align>
                 <aligny>center</aligny>
-                <label>$INFO[Container(9500).ListItem.VideoCodec,,  •  ]$INFO[Container(9500).ListItem.VideoResolution]$INFO[Container(9500).ListItem.VideoAspect,  •  ,]$VAR[LabelFurniturehdr,  •  ,]</label>
+                <label>$INFO[Container(9500).ListItem.VideoCodec,,  •  ]$INFO[Container(9500).ListItem.VideoResolution]$INFO[Container(9500).ListItem.VideoAspect,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <font>Flag</font>
                 <textcolor>Dark1</textcolor>
                 <visible>!Skin.HasSetting(furniture.flagicons) + !String.IsEmpty(Container(9500).ListItem.VideoResolution)</visible>
@@ -2655,7 +2655,7 @@
                 <centertop>50%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagicons) + [String.Contains(Container(9500).ListItem.Filenameandpath,.hdr.) | String.Contains(Container(9500).ListItem.Filenameandpath,hdr)]</visible>
+                <visible>Skin.HasSetting(furniture.flagicons) + $EXP[IsVideoHDR]</visible>
             </control>
             <control type="image">
                 <width min="20" max="100">auto</width>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -194,7 +194,7 @@
                     <top>10</top>
                     <font>Flag</font>
                     <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodecPlayer,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
                     <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
                 </control>
                 <control type="image">
@@ -225,7 +225,7 @@
                     <width min="20" max="90">auto</width>
                     <height>56</height>
                     <centertop>53%</centertop>
-                    <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$VAR[ListItemAudioCodecPlayer,flags3/audio/,.png]</texture>
+                    <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags3/audio/,.png]</texture>
                     <aspectratio align="center">keep</aspectratio>
                     <visible>!String.IsEmpty(VideoPlayer.AudioCodec) + Skin.HasSetting(furniture.flagiconsosdnoicons)</visible>
                 </control>
@@ -296,7 +296,7 @@
                     <top>10</top>
                     <font>Flag</font>
                     <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodecPlayer,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
                     <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
                 </control>
                 <control type="image">
@@ -327,7 +327,7 @@
                     <width min="20" max="98">auto</width>
                     <height>55</height>
                     <centertop>53%</centertop>
-                    <texture fallback="flags/fallback.png">$VAR[ListItemAudioCodecPlayer,flags/color/audio/,.png]</texture>
+                    <texture fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags/color/audio/,.png]</texture>
                     <aspectratio align="center">keep</aspectratio>
                     <visible>!String.IsEmpty(VideoPlayer.AudioCodec) + Skin.HasSetting(furniture.flagiconsosdnoicons)</visible>
                 </control>
@@ -595,7 +595,7 @@
                 <top>10</top>
                 <font>Flag</font>
                 <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodecPlayer,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
                 <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
             </control>
             <control type="image">
@@ -626,7 +626,7 @@
                 <width min="20" max="90">auto</width>
                 <height>56</height>
                 <centertop>53%</centertop>
-                <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$VAR[ListItemAudioCodecPlayer,flags3/audio/,.png]</texture>
+                <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags3/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagiconsosd) + !String.IsEmpty(VideoPlayer.AudioCodec) + Skin.HasSetting(furniture.flagiconsosdnoicons)</visible>
             </control>
@@ -733,7 +733,7 @@
                 <top>10</top>
                 <font>Flag</font>
                 <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodecPlayer,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
                 <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
             </control>
             <control type="image">
@@ -764,7 +764,7 @@
                 <width min="20" max="98">auto</width>
                 <height>55</height>
                 <centertop>53%</centertop>
-                <texture fallback="flags/fallback.png">$VAR[ListItemAudioCodecPlayer,flags/color/audio/,.png]</texture>
+                <texture fallback="flags/fallback.png">$VAR[ListItemAudioCodec,flags/color/audio/,.png]</texture>
                 <aspectratio align="center">keep</aspectratio>
                 <visible>Skin.HasSetting(furniture.flagiconsosd) + !String.IsEmpty(VideoPlayer.AudioCodec) + Skin.HasSetting(furniture.flagiconsosdnoicons)</visible>
             </control>

--- a/1080i/Includes_OSD.xml
+++ b/1080i/Includes_OSD.xml
@@ -194,7 +194,7 @@
                     <top>10</top>
                     <font>Flag</font>
                     <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                     <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
                 </control>
                 <control type="image">
@@ -244,7 +244,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr10plus.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10Plus]</visible>
                 </control>
                 <control type="image" description="HDR10">
                     <width min="20" max="100">auto</width>
@@ -252,7 +252,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr10.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10]</visible>
                 </control>
                 <control type="image" description="HDR">
                     <width min="20" max="100">auto</width>
@@ -260,7 +260,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hdr.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR]</visible>
                 </control>
                 <control type="image"  description="HLG">
                     <width min="20" max="100">auto</width>
@@ -268,7 +268,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filename,.hlg.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHLG]</visible>
                 </control>
                 <control type="image"  description="Dolby Vision">
                     <width min="20" max="100">auto</width>
@@ -276,7 +276,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/dolbyvision.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filename,.dv.) | String.Contains(Player.Filename,dolbyvision)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoDolbyVision]</visible>
                 </control>
 
             </control>
@@ -296,7 +296,7 @@
                     <top>10</top>
                     <font>Flag</font>
                     <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                    <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                     <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
                 </control>
                 <control type="image">
@@ -346,7 +346,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10Plus]</visible>
                 </control>
                 <control type="image" description="HDR10">
                     <width min="20" max="100">auto</width>
@@ -354,7 +354,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10]</visible>
                 </control>
                 <control type="image" description="HDR">
                     <width min="20" max="100">auto</width>
@@ -362,7 +362,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR]</visible>
                 </control>
                 <control type="image" description="HLG">
                     <width min="20" max="100">auto</width>
@@ -370,7 +370,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHLG]</visible>
                 </control>
                 <control type="image" description="Dolby Vision">
                     <width min="20" max="100">auto</width>
@@ -378,7 +378,7 @@
                     <centertop>53%</centertop>
                     <texture fallback="flags/fallback.png">flags/color/other/dolbyvision.png</texture>
                     <aspectratio align="center">keep</aspectratio>
-                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision)]</visible>
+                    <visible>Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoDolbyVision]</visible>
                 </control>
             </control>
 
@@ -595,7 +595,7 @@
                 <top>10</top>
                 <font>Flag</font>
                 <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
             </control>
             <control type="image">
@@ -645,7 +645,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10Plus]</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -653,7 +653,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10]</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -661,7 +661,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hdr.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR]</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="100">auto</width>
@@ -669,7 +669,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHLG]</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>
@@ -677,7 +677,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="$VAR[OSDPanelWhite70]" fallback="flags/fallback.png">flags/other/dolbyvision.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoDolbyVision]</visible>
             </control>
 
             <include content="Def_Flag">
@@ -733,7 +733,7 @@
                 <top>10</top>
                 <font>Flag</font>
                 <textcolor>$VAR[OSDPanelWhite30]</textcolor>
-                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[LabelOSDhdr,  •  ,]</label>
+                <label>$INFO[VideoPlayer.VideoCodec,,  •  ]$INFO[VideoPlayer.VideoResolution,,  •  ]$INFO[VideoPlayer.VideoAspect,,  •  ]$VAR[ListItemAudioCodec,,]$VAR[LabelOSDAudioChannels,  •  ,]$VAR[ListItemHDR,  •  ,]</label>
                 <visible>!Skin.HasSetting(furniture.flagiconsosdnoicons) + Skin.HasSetting(furniture.flagiconsosd)</visible>
             </control>
             <control type="image">
@@ -783,7 +783,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10plus.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10plus.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10Plus]</visible>
             </control>
             <control type="image" description="HDR10">
                 <width min="20" max="100">auto</width>
@@ -791,7 +791,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdr10.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr10.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR10]</visible>
             </control>
             <control type="image" description="HDR">
                 <width min="20" max="100">auto</width>
@@ -799,7 +799,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hdrnew.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hdr.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHDR]</visible>
             </control>
             <control type="image" description="HLG">
                 <width min="20" max="100">auto</width>
@@ -807,7 +807,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/hlg.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + String.Contains(Player.Filenameandpath,.hlg.)</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoHLG]</visible>
             </control>
             <control type="image" description="Dolby Vision">
                 <width min="20" max="100">auto</width>
@@ -815,7 +815,7 @@
                 <centertop>53%</centertop>
                 <texture fallback="flags/fallback.png">flags/color/other/dolbyvision.png</texture>
                 <aspectratio align="center">keep</aspectratio>
-                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + [String.Contains(Player.Filenameandpath,.dv.) | String.Contains(Player.Filenameandpath,dolbyvision)]</visible>
+                <visible>Skin.HasSetting(furniture.flagiconsosd) + Skin.HasSetting(furniture.flagiconsosdnoicons) + $EXP[IsVideoDolbyVision]</visible>
             </control>
 
             <include content="Def_Flag">


### PR DESCRIPTION
I think we can use expressions to reduce some duplicated code.

Im using the same conditional for ListItem + VideoPlayer, by my tests its fine. What do you think? 
Tell me if it is wrong 

Are we using the HUB thing? I dont know what is or how can I see... but there are some pieces of code that mention the `Container(9500)` and I assume that is for the Hub, I dont know how test it... looks like there are some outdated code there...

