### PR TITLE
Rename AnimatedPoster Setting furniture.animatedposters -> skinhelper…

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -120,7 +120,7 @@
     </variable>
 
     <variable name="PosterImage">        
-        <value condition="!String.IsEmpty(ListItem.Art(animatedposter)) + Skin.HasSetting(furniture.animatedposters)">$INFO[ListItem.Art(animatedposter)]</value>
+        <value condition="!String.IsEmpty(ListItem.Art(animatedposter)) + Skin.HasSetting(skinhelper.enableanimatedposters)">$INFO[ListItem.Art(animatedposter)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(season.poster)) + !Window.IsVisible(Home)">$INFO[ListItem.Art(season.poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(poster))">$INFO[ListItem.Art(poster)]</value>
         <value condition="!String.IsEmpty(ListItem.Art(tvshow.poster))">$INFO[ListItem.Art(tvshow.poster)]</value>

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -601,8 +601,8 @@
                     <include>DefContextButtonGradient</include>
                     <align>left</align>
                     <label>37500</label>
-                    <selected>Skin.HasSetting(furniture.animatedposters)</selected>
-                    <onclick>Skin.ToggleSetting(furniture.animatedposters)</onclick>
+                    <selected>Skin.HasSetting(skinhelper.enableanimatedposters)</selected>
+                    <onclick>Skin.ToggleSetting(skinhelper.enableanimatedposters)</onclick>
                 </control>
                 <control type="radiobutton" id="9086" description="AnimatedFanart">
                     <include>DefContextButtonGradient</include>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1601,8 +1601,8 @@
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
                             <label>37500</label>
-                            <selected>Skin.HasSetting(furniture.animatedposters)</selected>
-                            <onclick>Skin.ToggleSetting(furniture.animatedposters)</onclick>
+                            <selected>Skin.HasSetting(skinhelper.enableanimatedposters)</selected>
+                            <onclick>Skin.ToggleSetting(skinhelper.enableanimatedposters)</onclick>
                         </control>
                         <control type="radiobutton" id="9282">
                             <width>1310</width>


### PR DESCRIPTION
….enableanimatedposters

No impact on the Skin itself without script.skin.helper.service installed but when script.skin.helper.service is installed it grabs the setting and add a ContextMenu Option for Movies "Select Animated Art" which open DialogSelect to browse for a gif. The gif is saved then in userdata subdir "animatedgifs" from script.module.metadatautils and would added to the videodb.

Its an easy way to set a local saved Animated Gif to a Movie in the DB. 