### PR TITLE
[Flags] Disable the next aired information

### DIFF
--- a/1080i/Custom_Ratings.xml
+++ b/1080i/Custom_Ratings.xml
@@ -125,12 +125,19 @@
                 <control type="radiobutton" id="109">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
+                    <label>$LOCALIZE[31220]</label>
+                    <selected>!Skin.HasSetting(furniture.flags.nextaired)</selected>
+                    <onclick>Skin.ToggleSetting(furniture.flags.nextaired)</onclick>
+                </control>
+                <control type="radiobutton" id="110">
+                    <align>left</align>
+                    <include>DefContextButtonGradientSelect</include>
                     <label>$LOCALIZE[563]</label>
                     <visible>Skin.HasSetting(furniture.flagicons)</visible>
                     <selected>!Skin.HasSetting(furniture.flags.rating)</selected>
                     <onclick>Skin.ToggleSetting(furniture.flags.rating)</onclick>
                 </control>
-                <control type="radiobutton" id="110">
+                <control type="radiobutton" id="111">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
                     <label>$LOCALIZE[37742]$LOCALIZE[31218]</label>
@@ -139,27 +146,27 @@
                     <onclick>Skin.ToggleSetting(furniture.numericrating)</onclick>
                     <enable>!Skin.HasSetting(furniture.flags.rating)</enable>
                 </control>
-                <control type="radiobutton" id="111">
+                <control type="radiobutton" id="112">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
                     <label>37918</label>
                     <selected>Skin.HasSetting(furniture.showtomatoesandmetacritics)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showtomatoesandmetacritics)</onclick>
                 </control>
-                <control type="radiobutton" id="112">
+                <control type="radiobutton" id="113">
                     <align>left</align>
                     <include>DefContextButtonGradientSelect</include>
                     <label>38018</label>
                     <selected>Skin.HasSetting(furniture.showuserrating)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showuserrating)</onclick>
                 </control>
-                <control type="radiobutton" id="113">
+                <control type="radiobutton" id="114">
                     <include>DefContextButtonGradientSelect</include>
                     <label>37920</label>
                     <selected>Skin.HasSetting(furniture.showsubtitles)</selected>
                     <onclick>Skin.ToggleSetting(furniture.showsubtitles)</onclick>
                 </control>
-                <control type="radiobutton" id="114">
+                <control type="radiobutton" id="115">
                     <include>DefContextButtonGradientSelect</include>
                     <label>37921</label>
                     <selected>Skin.HasSetting(furniture.showsubtitles.enable.labels)</selected>

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -96,7 +96,7 @@
         | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.dv.) | String.Contains(Player.FileNameAndPath,dolbyvision) | String.Contains(Player.FileNameAndPath,dolby-vision)]]
     </expression>
     <expression name="HasNextAired">
-        [Container.Content(tvshows) | Container.Content(seasons)] 
+        [Container.Content(tvshows) | Container.Content(seasons) | String.IsEqual(ListItem.DBTYPE,tvshow) | String.IsEqual(ListItem.DBTYPE,season)] 
         + [!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))]
     </expression>
 

--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -95,6 +95,10 @@
         String.Contains(ListItem.FileNameAndPath,.dv.) | String.Contains(ListItem.FileNameAndPath,dolbyvision) | String.Contains(ListItem.FileNameAndPath,dolby-vision)
         | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.dv.) | String.Contains(Player.FileNameAndPath,dolbyvision) | String.Contains(Player.FileNameAndPath,dolby-vision)]]
     </expression>
+    <expression name="HasNextAired">
+        [Container.Content(tvshows) | Container.Content(seasons)] 
+        + [!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))]
+    </expression>
 
     <include name="ScrolltimeDetailsList">
         <scrolltime tween="sine" easing="inout">250</scrolltime>

--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -549,8 +549,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1">flags/airing.png</texture>
                     <aspectratio align="left">scale</aspectratio>
-                    <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                    <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                    <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
                 </control>
                 <control type="label">
                     <width min="128">auto</width>
@@ -561,8 +560,7 @@
                     <label>$VAR[LabelNextAiredDetails]</label>
                     <font>Flag</font>
                     <textcolor>Dark2</textcolor>
-                    <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                    <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                    <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -967,8 +965,7 @@
                     <centertop>50%</centertop>
                     <texture colordiffuse="Dark1">flags/airing.png</texture>
                     <aspectratio align="left">scale</aspectratio>
-                    <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                    <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                    <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
                 </control>
                 <control type="label">
                     <width min="128">auto</width>
@@ -979,8 +976,7 @@
                     <label>$VAR[LabelNextAiredDetails]</label>
                     <font>Flag</font>
                     <textcolor>Dark2</textcolor>
-                    <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                    <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                    <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
                 </control>
                 <control type="image">
                     <width min="20" max="100">auto</width>
@@ -1395,8 +1391,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1">flags/airing.png</texture>
                 <aspectratio align="left">scale</aspectratio>
-                <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
             </control>
             <control type="label">
                 <width min="128">auto</width>
@@ -1407,8 +1402,7 @@
                 <label>$VAR[LabelNextAiredDetails]</label>
                 <font>Flag</font>
                 <textcolor>Dark2</textcolor>
-                <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
             </control>
             <control type="image" description="Video Codec">
                 <width min="20" max="120">auto</width>
@@ -1818,8 +1812,7 @@
                 <centertop>50%</centertop>
                 <texture colordiffuse="Dark1">flags/airing.png</texture>
                 <aspectratio align="left">scale</aspectratio>
-                <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
             </control>
             <control type="label">
                 <width min="128">auto</width>
@@ -1830,8 +1823,7 @@
                 <label>$VAR[LabelNextAiredDetails]</label>
                 <font>Flag</font>
                 <textcolor>Dark2</textcolor>
-                <visible>[Container.Content(tvshows) | Container.Content(seasons)] + String.IsEmpty(ListItem.VideoResolution)</visible>
-                <visible>!String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Next_Aired)) | !String.IsEmpty(Window(Home).Property(TMDbHelper.ListItem.Last_Aired))</visible>
+                <visible>!Skin.HasSetting(furniture.flags.nextaired) + $EXP[HasNextAired]</visible>
             </control>
             <control type="image" description="Video Codec">
                 <width min="20" max="100">auto</width>


### PR DESCRIPTION
I also notice two things:

- is not showing in home widgets
- the 5 stars (without numeric) for tvshow/season are not working (but the numeric is)

I will investigate this better but in another PR

I think we should use more the `<expression>` what do you think? Is it fine or should I stop to use?