### PR TITLE
[Furniture] Fix clearlogo position for vertical netflix widget

### DIFF
--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -2959,8 +2959,8 @@
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
             <include>Animation.ClearLogo.FadeOut</include>
-            <animation effect="slide" start="0" end="0,-40" time="0" condition="$EXP[HomeIsVerticalMultiWidgets] + Window.IsVisible(Home.xml)">Conditional</animation>            
-            <visible>Skin.HasSetting(furniture.logo)</visible>            
+            <animation effect="slide" start="0" end="0,-40" time="0" condition="!Skin.HasSetting(homemenu.netflix) + $EXP[HomeIsVerticalMultiWidgets] + Window.IsVisible(Home.xml)">Conditional</animation>
+            <visible>Skin.HasSetting(furniture.logo)</visible>
             <visible>![Window.IsVisible(Home.xml) + Window.IsVisible(DialogVideoInfo.xml)]</visible>
             <visible>![Window.IsVisible(Home.xml) + Skin.HasSetting(home.showclearlogo) + $EXP[HomeIsVertical] ]</visible>
             <visible>![Window.IsVisible(Home.xml) + !Skin.HasSetting(home.showclearlogo) + $EXP[HomeIsVerticalMultiWidgets] ]</visible>

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -231,11 +231,11 @@
             </control>
             <control type="group">
                 <top>-20</top>
-                <animation effect="slide" start="0" end="0,40" time="0" condition="[Skin.HasSetting(home.modernwidgets)  + Skin.HasSetting(home.vertical.widgets)]">Conditional</animation>
+                <animation effect="slide" start="0" end="0,40" time="0" condition="Skin.HasSetting(home.modernwidgets) + Skin.HasSetting(home.vertical.widgets)">Conditional</animation>
                 <include>Furniture_Header</include>
             </control>
             <control type="group">
-                <animation effect="slide" start="0" end="0,20" time="0" condition="[Skin.HasSetting(home.modernwidgets)  + Skin.HasSetting(home.vertical.widgets)]">Conditional</animation>
+                <animation effect="slide" start="0" end="0,20" time="0" condition="Skin.HasSetting(home.modernwidgets) + Skin.HasSetting(home.vertical.widgets)">Conditional</animation>
                 <visible>Player.HasMedia</visible>
                 <include>Animation.FadeIn</include>
                 <include>Animation.FadeOut</include>


### PR DESCRIPTION
I said in the forum but I went a bit deeper and now I got what was the commit about.

We need to move a little bit upper the clearlogo when is Vertical Widgets... fine, but we dont need it to vertical netflix... So I change the conditional.

**Before**
![image](https://user-images.githubusercontent.com/15933/110206762-9e7afb80-7e77-11eb-8075-50de46c5e3ad.png)


**After**
![image](https://user-images.githubusercontent.com/15933/110206746-8dca8580-7e77-11eb-98cb-8ce2adb99ee5.png)

And still the same position for vertical widgets
![image](https://user-images.githubusercontent.com/15933/110206781-b5b9e900-7e77-11eb-9298-fa5661920a38.png)
