### PR TITLE
[SkinSettings] Choose indicators settings

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -4,20 +4,24 @@
     <variable name="PercentWatched">
         <value condition="Skin.HasSetting(hide.markers)"></value>
         <value condition="ListItem.IsPlaying">indicator/play.png</value>
+        <value condition="ListItem.IsResumable + Skin.HasSetting(hide.markers.inprogress)"></value>
         <value condition="ListItem.IsResumable">indicator/inprogress.png</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">indicator/checkmark.png</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]">indicator/new.png</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png)">indicator/unwatched.png</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">indicator/new.png</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !Skin.HasSetting(hide.markers.unwatched)">indicator/unwatched.png</value>
     </variable>
 
     <variable name="WatchedBacking">
         <value condition="Skin.HasSetting(hide.markers)"></value>
         <value condition="Skin.HasSetting(WatchedBackingOff)"/>
         <value condition="ListItem.IsPlaying">[COLOR=FF333333]&#61833;[/COLOR]</value>
+        <value condition="ListItem.IsResumable + Skin.HasSetting(hide.markers.inprogress)"></value>
         <value condition="ListItem.IsResumable">[COLOR=FF333333]&#61833;[/COLOR]</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">[COLOR=FF333333]&#61833;[/COLOR]</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]">[COLOR=FF333333]&#61833;[/COLOR]</value>
-        <!--<value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png)">indicator/backing.png</value>-->
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">[COLOR=FF333333]&#61833;[/COLOR]</value>
+        <!--<value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !Skin.HasSetting(hide.markers.unwatched)">indicator/backing.png</value>-->
     </variable>
 
     <variable name="WatchedBackingColor">

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -228,10 +228,12 @@
     <variable name="WatchedLabelPoster">
         <value condition="Skin.HasSetting(hide.markers)"></value>
         <value condition="ListItem.IsPlaying">[COLOR=WatchedIcons]&#62811;[/COLOR]</value>
+        <value condition="ListItem.IsResumable + Skin.HasSetting(hide.markers.inprogress)"></value>
         <value condition="ListItem.IsResumable">&#62596;</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">[COLOR=FF00DD44]&#10003;[/COLOR]</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
-        <!--<value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png)">&#63346;</value>-->
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
+        <!--<value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !Skin.HasSetting(hide.markers.unwatched)">&#63346;</value>-->
     </variable>
 
     <variable name="WatchedLabelPosterColor">
@@ -241,10 +243,12 @@
     <variable name="WatchedLabelList">
         <value condition="Skin.HasSetting(hide.markers)"></value>
         <value condition="ListItem.IsPlaying">&#62811;</value>
+        <value condition="ListItem.IsResumable + Skin.HasSetting(hide.markers.inprogress)"></value>
         <value condition="ListItem.IsResumable">&#62596;</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">[COLOR=FF00DD44]&#10003;[/COLOR]</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png)">&#61833;</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !Skin.HasSetting(hide.markers.unwatched)">&#61833;</value>
     </variable>
 
     <variable name="LabelwidgetListType">

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -8,7 +8,7 @@
         <include>Furniture_NowPlaying</include>
         <include>Furniture_Clock</include>
         <include>Furniture_Weather</include>
-        <include>OverlayEnableAddons</include>        
+        <include>OverlayEnableAddons</include>
         <control type="group">
             <include>Animation.Common</include>
             <left>72</left>
@@ -222,7 +222,7 @@
                             <onfocus>ClearProperty(Backg,Home)</onfocus>
                             <onfocus>ClearProperty(custommenu,Home)</onfocus>
                             <onfocus>ClearProperty(skinshortcuts-Widget,Home)</onfocus>
-                        </control>                        
+                        </control>
                         <control type="button" id="9805">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -493,7 +493,7 @@
                             <onclick condition="!Skin.HasSetting(extended.nowplaying.videowindow)">Skin.Reset(global.showvideo)</onclick>
                             <enable>Skin.HasSetting(extended.nowplaying)</enable>
                             <enable>[ $EXP[HomeIsModernMultiWidgets] | $EXP[HomeIsVerticalMultiWidgets] ]</enable>
-                        </control>                        
+                        </control>
                         <control type="radiobutton" id="9722" description="">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -526,7 +526,7 @@
                             <onclick condition="Skin.HasSetting(osd.music.disc.fallback.vinyl)">Skin.Reset(osd.music.disc.fallback.vinyl)</onclick>
                             <enable>Skin.HasSetting(extended.nowplaying) + !Skin.HasSetting(extended.nowplaying.hidecd)</enable>
                             <enable>[ $EXP[HomeIsModernMultiWidgets] | $EXP[HomeIsVerticalMultiWidgets] ]</enable>
-                        </control>                        
+                        </control>
                         <control type="button" id="9725">
                             <width>1310</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
@@ -577,7 +577,8 @@
                             <selected>Skin.HasSetting(home.showclearlogoleftbottomclassic)</selected>
                             <onclick>Skin.ToggleSetting(home.showclearlogoleftbottomclassic)</onclick>
                             <onclick>Skin.Reset(home.showclearlogotopright)</onclick>
-                        </control>                        
+                        </control>
+
                         <control type="button" id="9859">
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
                             <include>DefSettingsLabel</include>
@@ -705,7 +706,7 @@
                             <label>31172</label>
                             <selected>Skin.HasSetting(global.showvisualisation)</selected>
                             <onclick>Skin.ToggleSetting(global.showvisualisation)</onclick>
-                        </control>                        
+                        </control>
                     </control>
     
                     <!-- MUSIC Video OSD -->
@@ -1323,7 +1324,7 @@
                             <height>47</height>
                             <left>385</left>
                             <texture>backg/matrix.png</texture>
-                        </control>                        
+                        </control>
                         <control type="button" id="9907">
                             <width>1310</width>
                             <height>279</height>
@@ -1699,6 +1700,8 @@
                             <selected>Skin.HasSetting(dontuselandscapemovies)</selected>
                             <onclick>Skin.ToggleSetting(dontuselandscapemovies)</onclick>
                         </control>
+                        
+                        <!-- Indicators -->
                         <control type="radiobutton" id="9585">
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsButtonGradient</include>
@@ -1706,7 +1709,44 @@
                             <align>left</align>
                             <selected>!Skin.HasSetting(hide.markers)</selected>
                             <onclick>Skin.ToggleSetting(hide.markers)</onclick>
-                        </control>                        
+                        </control>
+                        <control type="radiobutton" id="9586">
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[575]</label>
+                            <align>left</align>
+                            <enable>!Skin.HasSetting(hide.markers)</enable>
+                            <selected>!Skin.HasSetting(hide.markers.inprogress)</selected>
+                            <onclick>Skin.ToggleSetting(hide.markers.inprogress)</onclick>
+                        </control>
+                        <control type="radiobutton" id="9587">
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[16101]</label>
+                            <align>left</align>
+                            <enable>!Skin.HasSetting(hide.markers)</enable>
+                            <selected>!Skin.HasSetting(hide.markers.unwatched)</selected>
+                            <onclick>Skin.ToggleSetting(hide.markers.unwatched)</onclick>
+                        </control>
+                        <control type="radiobutton" id="9588">
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[16102]</label>
+                            <align>left</align>
+                            <enable>!Skin.HasSetting(hide.markers)</enable>
+                            <selected>!Skin.HasSetting(hide.markers.watched)</selected>
+                            <onclick>Skin.ToggleSetting(hide.markers.watched)</onclick>
+                        </control>
+                        <control type="radiobutton" id="9589">
+                            <visible>ControlGroup(9100).HasFocus(9106)</visible>
+                            <include>DefSettingsButtonGradient</include>
+                            <label>$LOCALIZE[37742]$LOCALIZE[842]</label>
+                            <align>left</align>
+                            <enable>!Skin.HasSetting(hide.markers)</enable>
+                            <selected>!Skin.HasSetting(hide.markers.newcontent)</selected>
+                            <onclick>Skin.ToggleSetting(hide.markers.newcontent)</onclick>
+                        </control>
+
                         <control type="button" id="9296">
                             <visible>ControlGroup(9100).HasFocus(9106)</visible>
                             <include>DefSettingsLabel</include>
@@ -1771,7 +1811,7 @@
                             <label>37514</label>
                             <selected>Skin.HasSetting(thumbnails.white)</selected>
                             <onclick>Skin.ToggleSetting(thumbnails.white)</onclick>
-                        </control>                        
+                        </control>
                         <control type="button" id="12006">
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
                             <include>DefSettingsLabel</include>
@@ -1792,7 +1832,7 @@
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
                             <onclick>ActivateWindow(1254)</onclick>
                             <enable>Skin.HasSetting(enable.forcedviews)</enable>
-                        </control>                        
+                        </control>
                         <control type="button" id="12009">
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
                             <include>DefSettingsLabel</include>


### PR DESCRIPTION
This PR closes #106 and This PR depends on #109 

I think those settings is good because if you're using the list view you may see a lot of "dots" for unwatched content, like this:
![image](https://user-images.githubusercontent.com/15933/110247937-8d5ce800-7f66-11eb-86a9-4b9400482415.png)

I added to `Furniture` the options to select the flags: 
![image](https://user-images.githubusercontent.com/15933/110247865-42db6b80-7f66-11eb-8d68-de6db285b140.png)

The state of the options If `Indicators` is disable:
![image](https://user-images.githubusercontent.com/15933/110247885-5981c280-7f66-11eb-8b96-b8cf1e9330c2.png)

And the result could be (depends on the settings)
![image](https://user-images.githubusercontent.com/15933/110247897-630b2a80-7f66-11eb-93f8-3f1726af6895.png)

