### PR TITLE
[Viewtypelist] move "Poster wall small" under "Poster wall" in list Viewtype

### DIFF
--- a/1080i/Custom_SetViewtype.xml
+++ b/1080i/Custom_SetViewtype.xml
@@ -217,6 +217,15 @@
                     <onclick>Close</onclick>
                     <enable>!Container.Content(episodes) + !Container.Content(actors)</enable>
                 </control>
+                <control type="button" id="3143">
+                    <include>DefContextButtonGradient</include>
+                    <label>37782</label>
+                    <align>left</align>
+                    <include condition="Skin.HasSetting(enable.forcedviews)">unlock_views</include>
+                    <onclick>Container.SetViewMode(517)</onclick>
+                    <onclick>Close</onclick>
+                    <enable>Container.Content(musicvideos) | Container.Content(movies) | Container.Content(tvshows) | Container.Content(sets) | Container.Content(videos)</enable>
+                </control>
                 <control type="button" id="3128">
                     <include>DefContextButtonGradient</include>
                     <label>31147</label>
@@ -336,15 +345,6 @@
                     <onclick>Container.SetViewMode(519)</onclick>
                     <onclick>Close</onclick>
                     <enable>!Container.Content(episodes) + !Container.Content(actors)</enable>
-                </control>
-                <control type="button" id="3143">
-                    <include>DefContextButtonGradient</include>
-                    <label>37782</label>
-                    <align>left</align>
-                    <include condition="Skin.HasSetting(enable.forcedviews)">unlock_views</include>
-                    <onclick>Container.SetViewMode(517)</onclick>
-                    <onclick>Close</onclick>
-                    <enable>Container.Content(musicvideos) | Container.Content(movies) | Container.Content(tvshows) | Container.Content(sets) | Container.Content(videos)</enable>
                 </control>
                 <control type="button" id="3157">
                     <include>DefContextButtonGradient</include>


### PR DESCRIPTION
I often switch between "Poster Wall" and "Poster wall small"
this PR move "Poster wall small"  under "Poster Wall"  in list Viewtype .
If you are not agree so don't worry and please close this PR.
Thanks :)