### PR TITLE
[TV Show] disable some option in DialogSetting in DialogVideoInfo if TV Show

### DIFF
--- a/1080i/Custom_DialogSettings.xml
+++ b/1080i/Custom_DialogSettings.xml
@@ -99,6 +99,7 @@
                     <selected>Skin.HasSetting(showbutton.video.director)</selected>
                     <onclick>Skin.ToggleSetting(showbutton.video.director)</onclick>
                     <visible>Window.IsVisible(DialogVideoInfo.xml)</visible>
+                    <enable>Container.Content(movies)</enable>
                 </control>
                 <control type="radiobutton" id="136">
                     <include>DefContextButtonGradientSelect</include>
@@ -106,6 +107,7 @@
                     <selected>Skin.HasSetting(showbutton.video.set)</selected>
                     <onclick>Skin.ToggleSetting(showbutton.video.set)</onclick>
                     <visible>Window.IsVisible(DialogVideoInfo.xml)</visible>
+                    <enable>Container.Content(movies)</enable>
                 </control>
                 <control type="radiobutton" id="106">
                     <include>DefContextButtonGradientSelect</include>


### PR DESCRIPTION

 - showbutton.video.director
 - showbutton.video.set

are unnecessary for TV Shows

![2](https://user-images.githubusercontent.com/3939543/121375168-d1360380-c940-11eb-8652-b89add46219c.jpg)