### PR TITLE
[Scrollbar] Option to hide scrollbar for more views (Flix v2)

### DIFF
--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -78,7 +78,7 @@
           <texturesliderbackground border="4" colordiffuse="Dark4">scrollbar/scrollv.png</texturesliderbackground>
           <texturesliderbar border="4" colordiffuse="Dark3">scrollbar/scrollv.png</texturesliderbar>
           <texturesliderbarfocus border="4" colordiffuse="Dark2">scrollbar/scrollv.png</texturesliderbarfocus>
-          <animation effect="fade" start="100" end="0" time="400" condition="!Control.HasFocus($PARAM[scrollid]) + [!Container.Scrolling | [$PARAM[showscroll] + [Control.IsVisible(510) | Control.IsVisible(520)]]]">Conditional</animation>
+          <animation effect="fade" start="100" end="0" time="400" condition="!Control.HasFocus($PARAM[scrollid]) + [!Container.Scrolling | [$PARAM[showscroll] + [Control.IsVisible(510) | Control.IsVisible(520) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(524)]]]">Conditional</animation>
         </definition>
     </include>
 

--- a/1080i/MyVideoNav.xml
+++ b/1080i/MyVideoNav.xml
@@ -543,7 +543,7 @@
                     <label>37805</label>
                     <selected>!Skin.HasSetting(ShowScrollbar510)</selected>
                     <onclick>Skin.ToggleSetting(ShowScrollbar510)</onclick>
-                    <visible>Control.IsVisible(510) | Control.IsVisible(520)</visible>
+                    <visible>Control.IsVisible(510) | Control.IsVisible(520) | Control.IsVisible(521) | Control.IsVisible(522) | Control.IsVisible(523) | Control.IsVisible(524)</visible>
                 </control>
                 <control type="button" id="9070" description="Netflix Icon Size">
                     <include>DefContextButtonGradient</include>

--- a/1080i/View_510_Minimal.xml
+++ b/1080i/View_510_Minimal.xml
@@ -353,11 +353,11 @@
                 </control>
             </control>
             <control type="scrollbar" id="1651">
-                <bottom>162</bottom>
                 <include content="scrollbar_hor">
                     <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1651"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="162"/>
                 </include>
             </control>
             <include condition="!Skin.HasSetting(53poster.nowrap)">510Wrap</include>

--- a/1080i/View_520_Minimal.xml
+++ b/1080i/View_520_Minimal.xml
@@ -238,11 +238,11 @@
                 </control>
             </control>
             <control type="scrollbar" id="1658">
-                <bottom>162</bottom>
                 <include content="scrollbar_hor">
                     <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1658"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="162"/>
                 </include>
             </control>
             <include condition="!Skin.HasSetting(53poster.nowrap)">520Wrap</include>

--- a/1080i/View_521_Minimal_V2.xml
+++ b/1080i/View_521_Minimal_V2.xml
@@ -57,11 +57,11 @@
             <visible>Control.IsVisible(521)</visible>
             <include>View_522_Minimal_V2_Content</include>
             <control type="scrollbar" id="1644">
-                <bottom>180</bottom>
                 <include content="scrollbar_hor">
-                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar521)" />
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1644"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="162"/>
                 </include>
             </control>
             <include condition="!Skin.HasSetting(53poster.nowrap)">521Wrap</include>

--- a/1080i/View_522_Minimal_V2_Episodes.xml
+++ b/1080i/View_522_Minimal_V2_Episodes.xml
@@ -57,11 +57,11 @@
             <visible>Control.IsVisible(522)</visible>
             <include>View_522_Minimal_V2_Content</include>
             <control type="scrollbar" id="1646">
-                <bottom>180</bottom>
                 <include content="scrollbar_hor">
-                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar522)" />
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1646"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="180"/>
                 </include>
             </control>
             <include condition="!Skin.HasSetting(53poster.nowrap)">522Wrap</include>

--- a/1080i/View_523_Minimal_V2_Music.xml
+++ b/1080i/View_523_Minimal_V2_Music.xml
@@ -61,11 +61,11 @@
             <visible>Control.IsVisible(523)</visible>
             <include>View_523_Minimal_V2_Content_Music</include>
             <control type="scrollbar" id="1644">
-                <bottom>180</bottom>
                 <include content="scrollbar_hor">
-                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar523)" />
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1644"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="180"/>
                 </include>
             </control>
             <control type="list" id="5231">

--- a/1080i/View_524_Minimal_V2_Seasons.xml
+++ b/1080i/View_524_Minimal_V2_Seasons.xml
@@ -57,11 +57,11 @@
             <visible>Control.IsVisible(524)</visible>
             <include>View_522_Minimal_V2_Content</include>
             <control type="scrollbar" id="1644">
-                <bottom>180</bottom>
                 <include content="scrollbar_hor">
-                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar524)" />
+                    <param name="showscroll" value="Skin.HasSetting(ShowScrollbar510)" />
                     <param name="scrollid" value="1644"/>
                     <param name="jumpbar" value="false"/>
+                    <param name="bottom" value="180"/>
                 </include>
             </control>
             <include condition="!Skin.HasSetting(53poster.nowrap)">524Wrap</include>


### PR DESCRIPTION
Hello, its been a while since my last contribution but Im still following (and using daily) the theme. I've notice the new Flix views and its amazing! 

Just one thing I did in the past (#67) about the Flix v1, its the ability to hide the scrollbars animations when it's scrolling. The scroll still there but will need to be focused to be visible. 

Since we already have the option `ShowScrollbar510` and I notice the new views use the `scrollbar_hor` as well, I think I can reuse it.