### PR TITLE
[Bugfix] Netflix fullsize fanart

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -762,7 +762,7 @@
             <timeperimage>HomeTimePerImage</timeperimage>
             <randomize>true</randomize>
             <aspectratio>scale</aspectratio>
-            <include condition="Skin.HasSetting(homemenu.netflix.preview.fullscreen) + !Skin.HasSetting(hide.homemenu.netflix.preview) + Skin.HasSetting(BlurEnabled) + Skin.HasSetting(BlurOnHome)">NetflixPreviewWindowFullscreen</include>
+            <include condition="Skin.HasSetting(homemenu.netflix.preview.fullscreen) + !Skin.HasSetting(hide.homemenu.netflix.preview) + Skin.HasSetting(BlurEnabled) + [Skin.HasSetting(BlurOnHome) | !Window.IsVisible(Home.xml)]">NetflixPreviewWindowFullscreen</include>
             <include condition="!Skin.HasSetting(homemenu.netflix.preview.fullscreen) | [!Skin.HasSetting(BlurEnabled) | [Skin.HasSetting(BlurEnabled) + !Skin.HasSetting(BlurOnHome)]]">NetflixPreviewWindow</include>
             <animation effect="zoom" start="110" end="120" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(Fanart.Animate)">Conditional</animation>
             <animation effect="slide" start="-20,-20" end="20,20" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(Fanart.Animate)">Conditional</animation>


### PR DESCRIPTION
I was trying the home "clean & minimal" so I disabled the "blur on home"

![](https://i.imgur.com/C5K6IuD.png)

But Im still using the Flix views, then I notice the fullsize fanart stopped to work

![](https://i.imgur.com/eAmp63f.png)

The fix is just to remove the `BlurOnHome` conditional for that, worked here but Im not sure if that's all (I hope so)

![](https://i.imgur.com/D4vYsdV.png)

