### PR TITLE
[Clearlogo] Fix clearlogo position top position for Modern Widgets

### DIFF
--- a/1080i/Includes_Furniture.xml
+++ b/1080i/Includes_Furniture.xml
@@ -3103,7 +3103,6 @@
             <include>Animation.FadeIn</include>
             <include>Animation.FadeOut</include>
             <include>Animation.ClearLogo.FadeOut</include>
-            <animation effect="slide" start="0" end="0,-40" time="0" condition="!Skin.HasSetting(homemenu.netflix) + $EXP[HomeIsVerticalMultiWidgets] + Window.IsVisible(Home.xml)">Conditional</animation>
             <visible>Skin.HasSetting(furniture.logo)</visible>
             <visible>![Window.IsVisible(Home.xml) + Window.IsVisible(DialogVideoInfo.xml)]</visible>
             <visible>![Window.IsVisible(Home.xml) + Skin.HasSetting(home.showclearlogo) + $EXP[HomeIsVertical] ]</visible>
@@ -3111,6 +3110,7 @@
             <visible>![Control.IsVisible(504) + Skin.HasSetting(504clearlogo)]</visible>
             <visible>![Control.IsVisible(509) + Skin.HasSetting(509clearlogo)]</visible>
             <visible>![Control.IsVisible(510) + Skin.HasSetting(ShowClearart510)]</visible>
+            <animation effect="slide" start="0" end="0,60" time="0" condition="$EXP[HomeIsModernMultiWidgets] + Window.IsVisible(Home.xml)">Conditional</animation>
             <centertop>120</centertop>
             <centerleft>50%</centerleft>
             <width>400</width>

--- a/1080i/View_521_Minimal_V2.xml
+++ b/1080i/View_521_Minimal_V2.xml
@@ -135,7 +135,6 @@
                     <height>15</height>
                     <textcolor>Dark2</textcolor>
                     <selectedcolor>Dark2</selectedcolor>
-                    <label />
                 </control>
                 <control type="textbox">
                     <font>Tiny</font>


### PR DESCRIPTION
When you're on Modern Widgets and have the clearlogo enabled, you see missaligned (compared to the views)

![image (1)](https://user-images.githubusercontent.com/15933/123497183-040c1700-d624-11eb-828e-3c15425592c2.png)

This MR fixed it

![image](https://user-images.githubusercontent.com/15933/123497187-0a01f800-d624-11eb-91f1-f2301475838e.png)

Would be nice to know better WHY this happens instead of just conditionally fix the position... but... that's what I got xD