### PR TITLE
[Clearlogo] Flix v2 clearlogo align with widgets

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -1715,6 +1715,7 @@
                             <label>31115</label>
                             <selected>!Skin.HasSetting(furniture.header)</selected>
                             <onclick>Skin.ToggleSetting(furniture.header)</onclick>
+                            <onclick condition="Skin.HasSetting(home.showheader)">Skin.Reset(home.showheader)</onclick>
                         </control>
                         <control type="radiobutton" id="9252" description="Clock">
                             <width>1310</width>

--- a/1080i/View_521_Minimal_V2.xml
+++ b/1080i/View_521_Minimal_V2.xml
@@ -72,11 +72,17 @@
     <include name="View_522_Minimal_V2_Content">
         <control type="group">
             <left>SidePad</left>
-            <include content="def_top" condition="!Skin.HasSetting(home.widgets.show.reflections)">
+            <include content="def_top" condition="!Skin.HasSetting(home.widgets.show.reflections) + !Skin.HasSetting(furniture.header)">
                 <param name="top" value="195" />
             </include>
-            <include content="def_top" condition="Skin.HasSetting(home.widgets.show.reflections)">
+            <include content="def_top" condition="Skin.HasSetting(home.widgets.show.reflections) + !Skin.HasSetting(furniture.header)">
                 <param name="top" value="191" />
+            </include>
+            <include content="def_top" condition="!Skin.HasSetting(home.widgets.show.reflections) + Skin.HasSetting(furniture.header)">
+                <param name="top" value="117" />
+            </include>
+            <include content="def_top" condition="Skin.HasSetting(home.widgets.show.reflections) + Skin.HasSetting(furniture.header)">
+                <param name="top" value="105" />
             </include>
             <width>800</width>
             <control type="label">


### PR DESCRIPTION
Im trying to align the clearlogo (netflix style, the one that replaces the title) for the Modern home and the Flix v2, only when the header is disable, because I notice we have space for it....

Also, I notice when you disable the headers, the "home header" option doesn't work, so I connect the options

![Screenshot 2021-06-26 at 02 03 33](https://user-images.githubusercontent.com/15933/123496985-f1451280-d622-11eb-9eb6-7be899c6ba0d.png)

![Screenshot 2021-06-26 at 02 04 46](https://user-images.githubusercontent.com/15933/123496988-f5713000-d622-11eb-9a64-50c2c2185438.png)

