### PR TITLE
[Show now playing info] improvement "paused" information

### DIFF
--- a/1080i/Includes_NowPlaying.xml
+++ b/1080i/Includes_NowPlaying.xml
@@ -315,7 +315,7 @@
                 <param name="top" value="74" />
             </include>
             <left>155</left>
-            <visible>Player.HasMedia + Player.HasAudio + !Player.Paused</visible>
+            <visible>Player.HasMedia + Player.HasAudio</visible>
             <visible>!Skin.HasSetting(extended.nowplaying.hidecd)</visible>
             <include content="DefDiscArtNowPlaying">
                 <param name="visible" value="Skin.HasSetting(osd.music.disc.fake.cd)" />
@@ -351,7 +351,7 @@
                 <param name="top" value="74" />
             </include>
             <left>$PARAM[left]</left>
-            <visible>Player.HasMedia + Player.HasVideo + VideoPlayer.Content(movies) + !Player.Paused</visible>
+            <visible>Player.HasMedia + Player.HasVideo + VideoPlayer.Content(movies)</visible>
             <visible>!Skin.HasSetting(extended.nowplaying.hidecd)</visible>
             <include content="DefDiscArtNowPlaying">
                 <param name="visible" value="Skin.HasSetting(home.video.disc.fake.bluray)" />

--- a/1080i/Includes_NowPlaying.xml
+++ b/1080i/Includes_NowPlaying.xml
@@ -224,6 +224,15 @@
                     <width>auto</width>
                     <textcolor>Dark1</textcolor>
                     <label>31236</label>
+                    <visible>!Player.Paused</visible>
+                </control>
+                <control type="label">
+                    <height>38</height>
+                    <font>SmallNavi</font>
+                    <width>auto</width>
+                    <textcolor>Dark1</textcolor>
+                    <label>31492</label>
+                    <visible>Player.Paused</visible>
                 </control>
             </control>
             <control type="grouplist">
@@ -306,7 +315,7 @@
                 <param name="top" value="74" />
             </include>
             <left>155</left>
-            <visible>Player.HasMedia + Player.HasAudio</visible>
+            <visible>Player.HasMedia + Player.HasAudio + !Player.Paused</visible>
             <visible>!Skin.HasSetting(extended.nowplaying.hidecd)</visible>
             <include content="DefDiscArtNowPlaying">
                 <param name="visible" value="Skin.HasSetting(osd.music.disc.fake.cd)" />
@@ -342,7 +351,7 @@
                 <param name="top" value="74" />
             </include>
             <left>$PARAM[left]</left>
-            <visible>Player.HasMedia + Player.HasVideo + VideoPlayer.Content(movies)</visible>
+            <visible>Player.HasMedia + Player.HasVideo + VideoPlayer.Content(movies) + !Player.Paused</visible>
             <visible>!Skin.HasSetting(extended.nowplaying.hidecd)</visible>
             <include content="DefDiscArtNowPlaying">
                 <param name="visible" value="Skin.HasSetting(home.video.disc.fake.bluray)" />


### PR DESCRIPTION
when playing is paused with "Show now playing info"

![1](https://user-images.githubusercontent.com/3939543/124910538-fd9a7980-dfeb-11eb-80b2-7cd7faca8298.jpg)
