### PR TITLE
Workflow and errors

### DIFF
--- a/.github/workflows/sync-addon-metadata-translations.yml
+++ b/.github/workflows/sync-addon-metadata-translations.yml
@@ -1,0 +1,57 @@
+name: Sync addon metadata translations
+
+on:
+  push:
+    branches: [ master, main ]
+    paths:
+      - '**addon.xml'
+      - '**resource.language.**strings.po'
+
+jobs:
+  default:
+    if: github.repository == 'beatmasterRS/skin.arctic.zephyr.mod'
+    runs-on: ubuntu-latest
+
+    strategy:
+
+      fail-fast: false
+      matrix:
+        python-version: [ 3.9 ]
+
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: project
+
+      - name: Checkout sync_addon_metadata_translations repository
+        uses: actions/checkout@v2
+        with:
+          repository: xbmc/sync_addon_metadata_translations
+          path: sync_addon_metadata_translations
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install sync_addon_metadata_translations/
+
+      - name: Run sync-addon-metadata-translations
+        run: |
+          sync-addon-metadata-translations
+        working-directory: ./project
+
+      - name: Create PR for sync-addon-metadata-translations changes
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          commit-message: Sync of addon metadata translations
+          title: Sync of addon metadata translations
+          body: Sync of addon metadata translations triggered by ${{ github.sha }}
+          branch: amt-sync
+          delete-branch: true
+          path: ./project

--- a/language/resource.language.it_it/strings.po
+++ b/language/resource.language.it_it/strings.po
@@ -1258,7 +1258,7 @@ msgstr ""
 
 msgctxt "#31310"
 msgid "Enable grid"
-msgstr Abilita griglia""
+msgstr "Abilita griglia"
 
 msgctxt "#31311"
 msgid "Hide play/pause info"


### PR DESCRIPTION
This will add a workflow to automatically sync `summary`, `description` and `disclaimer` between language files and addon.xml

It will run whenever either language files or addon.xml are changed, and will create PR's for the changes.

This will also fix a syntax error in `it_it` language file.
It's necessary to fix to add the skin for translation at Weblate.