### PR TITLE
[Homemenu Animation] added option to slide out home menu items, if no…

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -78,7 +78,8 @@
     <expression name="Widget4Enabled">String.IsEqual(Container(300).ListItem.Property(widgetEnable.4),yes)</expression>
     <expression name="Widget5Enabled">String.IsEqual(Container(300).ListItem.Property(widgetEnable.5),yes)</expression>
     <expression name="Widget6Enabled">String.IsEqual(Container(300).ListItem.Property(widgetEnable.6),yes)</expression>
-    <expression name="HasHomemenuAutoSlideOutAnimation">Skin.HasSetting(homemenu.horizontal.slide) + $EXP[HomeIsModernMultiWidgets] + !Skin.HasSetting(homemenu.clean.flix)</expression>
+    <expression name="HasHomemenuAutoSlideOutAnimation">Skin.HasSetting(homemenu.slide) + [[$EXP[HomeIsModernMultiWidgets] + !Skin.HasSetting(homemenu.clean.flix)] | [$EXP[HomeIsVerticalMultiWidgets] + !Skin.HasSetting(homemenu.vertical.noslide)]]</expression>
+
     <expression name="IsAudioCodecATMOS">
         String.Contains(ListItem.FileNameAndPath,.atmos.) | String.Contains(ListItem.FileNameAndPath,.atmos-)
         | [VideoPlayer.IsFullscreen + [String.Contains(Player.FileNameAndPath,.atmos.) | String.Contains(Player.FileNameAndPath,.atmos-)]]

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -4700,6 +4700,7 @@
 
                          <!-- Set TMDbHelper WidgetContainer -->
                         <include condition="$EXP[HomeIsModernMultiWidgets] | $EXP[HomeIsVerticalMultiWidgets]">SetWidgetContainerForTMDB</include>
+                        <include condition="$EXP[HasHomemenuAutoSlideOutAnimation]">SlideOutItemsButton</include>
                     </focusedlayout>
                     <content>
                         <include>skinshortcuts-mainmenu</include>
@@ -4808,6 +4809,7 @@
                                 <texture colordiffuse="$VAR[ColorHighlightSelectbox2]">common/gradient-box.png</texture>
                             </control>
                         </control>
+                        <include condition="$EXP[HasHomemenuAutoSlideOutAnimation]">SlideOutItemsButton</include>
                     </focusedlayout>
                     <content>
                         <include>skinshortcuts-submenu</include>

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -438,9 +438,9 @@
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
                             <include>DefSettingsButtonGradientSkinSettings</include>
                             <label>$LOCALIZE[31556]</label>
-                            <selected>Skin.HasSetting(homemenu.horizontal.slide)</selected>
-                            <onclick>Skin.ToggleSetting(homemenu.horizontal.slide)</onclick>
-                            <visible>$EXP[HomeIsModernMultiWidgets] + !Skin.HasSetting(homemenu.clean.flix)</visible>
+                            <selected>Skin.HasSetting(homemenu.slide)</selected>
+                            <onclick>Skin.ToggleSetting(homemenu.slide)</onclick>
+                            <visible>[$EXP[HomeIsModernMultiWidgets] + !Skin.HasSetting(homemenu.clean.flix)] | [$EXP[HomeIsVerticalMultiWidgets] + !Skin.HasSetting(homemenu.vertical.noslide)]</visible>
                         </control>
                         <control type="grouplist" id="9803">
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>


### PR DESCRIPTION
…t used/focused

Same than horizontal for vertical : 

- option "Hide, when not focused/used" extended to "Vertical"
- option "Hide, when not focused/used" hidden if "On focus don't slide left" is enable
- "homemenu.horizontal.slide" rename to "homemenu.slide"

![screenshot00017](https://user-images.githubusercontent.com/3939543/126290888-037af5f7-e21e-4884-87d1-3b22f3ea70cc.png)
