### PR TITLE
[SkinSettings] improvement

### DIFF
--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -418,6 +418,7 @@
                         <control type="radiobutton" id="9898" description="Horz Sub">
                             <width>1360</width>
                             <visible>ControlGroup(9100).HasFocus(9101)</visible>
+                            <visible>$EXP[HomeIsModernMultiWidgets]</visible>
                             <include>DefSettingsButtonGradientSkinSettings</include>
                             <label>31202</label>
                             <selected>Skin.HasSetting(home.submenu2)</selected>
@@ -2472,6 +2473,7 @@
                         <control type="radiobutton" id="12011">
                             <width>1360</width>
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
+                            <visible>$EXP[HomeIsModernMultiWidgets]</visible>
                             <include>DefSettingsButtonGradientSkinSettings</include>
                             <label>31503</label>
                             <selected>Skin.HasSetting(disable.widgets.onup.go.back.to.last.item)</selected>
@@ -2481,6 +2483,7 @@
                         <control type="radiobutton" id="12012">
                             <width>1360</width>
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
+                            <visible>$EXP[HomeIsModernMultiWidgets]</visible>
                             <include>DefSettingsButtonGradientSkinSettings</include>
                             <label>31504</label>
                             <selected>Skin.HasSetting(disable.widgets.ondown.go.back.to.position.0)</selected>
@@ -2490,6 +2493,7 @@
                         <control type="radiobutton" id="12030">
                             <width>1360</width>
                             <visible>ControlGroup(9100).HasFocus(9107)</visible>
+                            <visible>$EXP[HomeIsVerticalMultiWidgets]</visible>
                             <include>DefSettingsButtonGradientSkinSettings</include>
                             <label>31505</label>
                             <selected>Skin.HasSetting(enable.widgets.onup.go.back.to.last.widget)</selected>


### PR DESCRIPTION
hide settings not `<enable>` in all case for selected layout is more clean less confuse.

before : 

![1](https://user-images.githubusercontent.com/3939543/127740075-6afaa3c4-a1f5-464a-b527-b467e65b3a5b.jpg)

after : 

![2](https://user-images.githubusercontent.com/3939543/127740086-12d545b9-1a14-4497-a559-0d8595d19fa1.jpg)

before : 

![3](https://user-images.githubusercontent.com/3939543/127740088-fa3d2c75-d493-404e-8f01-df5ec9d01908.jpg)

after : 

![5](https://user-images.githubusercontent.com/3939543/127741538-fd69fdab-72e2-4060-b991-7eed68cc0aec.jpg)

