### PR TITLE
[SettingsScreenCalibration] Fix and improvement

### DIFF
--- a/1080i/SettingsScreenCalibration.xml
+++ b/1080i/SettingsScreenCalibration.xml
@@ -7,10 +7,6 @@
             <description>videowindow</description>
             <include>Dimensions_Fullscreen</include>
         </control>
-        <control type="image">
-            <aspectratio>scale</aspectratio>
-            <texture border="5">special://skin/extras/backgrounds/systeminfo.jpg</texture>
-        </control>
         <control type="mover" id="8">
             <description>top left mover</description>
             <posx>0</posx>
@@ -53,6 +49,7 @@
             <posy>60</posy>
             <width>1860</width>
             <align>center</align>
+            <textcolor>PanelWhite100</textcolor>
             <label />
         </control>
         <control type="label" id="3">
@@ -61,6 +58,7 @@
             <posy>105</posy>
             <width>1860</width>
             <align>center</align>
+            <textcolor>PanelWhite100</textcolor>
             <label />
         </control>
     </controls>

--- a/1080i/SettingsScreenCalibration.xml
+++ b/1080i/SettingsScreenCalibration.xml
@@ -7,13 +7,17 @@
             <description>videowindow</description>
             <include>Dimensions_Fullscreen</include>
         </control>
+        <control type="image">
+            <aspectratio>scale</aspectratio>
+            <texture border="5">special://skin/extras/backgrounds/systeminfo.jpg</texture>
+        </control>
         <control type="mover" id="8">
             <description>top left mover</description>
             <posx>0</posx>
             <posy>0</posy>
             <width>192</width>
             <height>192</height>
-            <texturefocus>other_textures/CalibrateTopLeft.png</texturefocus>
+            <texturefocus>other_textures/calibratetopleft.png</texturefocus>
             <texturenofocus />
         </control>
         <control type="mover" id="9">
@@ -22,7 +26,7 @@
             <posy>750</posy>
             <width>192</width>
             <height>192</height>
-            <texturefocus>other_textures/CalibrateBottomRight.png</texturefocus>
+            <texturefocus>other_textures/calibratebottomright.png</texturefocus>
             <texturenofocus />
         </control>
         <control type="mover" id="10">
@@ -31,7 +35,7 @@
             <posy>750</posy>
             <width>768</width>
             <height>192</height>
-            <texturefocus>other_textures/CalibrateSubTitles.png</texturefocus>
+            <texturefocus>other_textures/calibratesubtitles.png</texturefocus>
             <texturenofocus />
         </control>
         <control type="resize" id="11">
@@ -40,7 +44,7 @@
             <posy>348</posy>
             <width>384</width>
             <height>384</height>
-            <texturefocus>other_textures/CalibratePixelRatio.png</texturefocus>
+            <texturefocus>other_textures/calibratepixelratio.png</texturefocus>
             <texturenofocus />
         </control>
         <control type="label" id="2">


### PR DESCRIPTION
- fix : 

uppercase to lowercase for textures files name

- improvement : 

add a background. It's not to look pretty :D 
when the background is almost completely black, some TV automatically lowers the brightness.

Before :  

![1](https://user-images.githubusercontent.com/3939543/130320450-7c710753-76b4-41d3-b1e0-6e631c6a97e0.png)

After fix : 

![2](https://user-images.githubusercontent.com/3939543/130320452-9a4a7827-beb0-4e68-804a-65bf9389add9.png)

After improvement : 

![3](https://user-images.githubusercontent.com/3939543/130320458-0f49e3b3-ac30-476e-aca8-e8b7a8c47f9a.png)


