### PR TITLE
[Video Information Dialog] add indicators status

### DIFF
--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -1343,26 +1343,31 @@
                 <visible>!Skin.HasSetting(thumbnails.white)</visible>
                 <texture colordiffuse="Box2" border="4">common/box21.png</texture>
             </control>
+
+            <include content="IndicatorPosterInfoDialog">
+                <param name="indicatorbackground" value="$PARAM[indicatorbackground]" />
+            </include>
+
             <control type="group">
                 <visible>$PARAM[storageicon]</visible>
-                <right>5</right>
-                <top>1</top>
+                <left>5</left>
+                <bottom>1</bottom>
                 <control type="label">
-                    <align>right</align>
+                    <align>left</align>
                     <aligny>center</aligny>
                     <width>50</width>
-                    <right>30</right>
-                    <top>6</top>
+                    <left>15</left>
+                    <bottom>6</bottom>
                     <height>50</height>
                     <font>SymbolPosterBackground</font>
                     <label>[COLOR=FF333333]&#61833;[/COLOR]</label>
                 </control>
                 <control type="label">
-                    <align>right</align>
+                    <align>left</align>
                     <aligny>center</aligny>
                     <width>50</width>
-                    <right>37</right>
-                    <top>6</top>
+                    <left>22</left>
+                    <bottom>6</bottom>
                     <height>50</height>
                     <textcolor>$VAR[WatchedLabelPosterColor]</textcolor>
                     <selectedcolor>$VAR[WatchedLabelPosterColor]</selectedcolor>
@@ -1408,26 +1413,31 @@
                 <visible>!Skin.HasSetting(thumbnails.white)</visible>
                 <texture colordiffuse="Box2" border="4">common/box21.png</texture>
             </control>
+
+            <include content="IndicatorPosterInfoDialog">
+                <param name="indicatorbackground" value="$PARAM[indicatorbackground]" />
+            </include>
+
             <control type="group">
                 <visible>$PARAM[storageicon]</visible>
-                <right>5</right>
-                <top>1</top>
+                <left>5</left>
+                <bottom>1</bottom>
                 <control type="label">
-                    <align>right</align>
+                    <align>left</align>
                     <aligny>center</aligny>
                     <width>50</width>
-                    <right>30</right>
-                    <top>6</top>
+                    <left>15</left>
+                    <bottom>6</bottom>
                     <height>50</height>
                     <font>SymbolPosterBackground</font>
                     <label>[COLOR=FF333333]&#61833;[/COLOR]</label>
                 </control>
                 <control type="label">
-                    <align>right</align>
+                    <align>left</align>
                     <aligny>center</aligny>
                     <width>50</width>
-                    <right>37</right>
-                    <top>6</top>
+                    <left>22</left>
+                    <bottom>6</bottom>
                     <height>50</height>
                     <textcolor>$VAR[WatchedLabelPosterColor]</textcolor>
                     <selectedcolor>$VAR[WatchedLabelPosterColor]</selectedcolor>
@@ -1837,26 +1847,31 @@
                     <visible>!Skin.HasSetting(thumbnails.white)</visible>
                     <texture colordiffuse="BoxNotification" border="4">common/box21.png</texture>
                 </control>
+
+                <include content="IndicatorPosterInfoDialog">
+                    <param name="indicatorbackground" value="$PARAM[indicatorbackground]" />
+                </include>
+
                 <control type="group">
                     <visible>$PARAM[storageicon]</visible>
-                    <right>5</right>
-                    <top>1</top>
+                    <left>5</left>
+                    <bottom>1</bottom>
                     <control type="label">
-                        <align>right</align>
+                        <align>left</align>
                         <aligny>center</aligny>
                         <width>50</width>
-                        <right>30</right>
-                        <top>6</top>
+                        <left>15</left>
+                        <bottom>6</bottom>
                         <height>50</height>
                         <font>SymbolPosterBackground</font>
                         <label>[COLOR=FF333333]&#61833;[/COLOR]</label>
                     </control>
                     <control type="label">
-                        <align>right</align>
+                        <align>left</align>
                         <aligny>center</aligny>
                         <width>50</width>
-                        <right>37</right>
-                        <top>6</top>
+                        <left>22</left>
+                        <bottom>6</bottom>
                         <height>50</height>
                         <textcolor>$VAR[WatchedLabelPosterColor]</textcolor>
                         <selectedcolor>$VAR[WatchedLabelPosterColor]</selectedcolor>
@@ -1944,26 +1959,31 @@
                     <visible>!Skin.HasSetting(thumbnails.white)</visible>
                     <texture colordiffuse="BoxNotification" border="4">common/box21.png</texture>
                 </control>
+
+                <include content="IndicatorPosterInfoDialog">
+                    <param name="indicatorbackground" value="$PARAM[indicatorbackground]" />
+                </include>
+
                 <control type="group">
                     <visible>$PARAM[storageicon]</visible>
-                    <right>5</right>
-                    <top>1</top>
+                    <left>5</left>
+                    <bottom>1</bottom>
                     <control type="label">
-                        <align>right</align>
+                        <align>left</align>
                         <aligny>center</aligny>
                         <width>50</width>
-                        <right>30</right>
-                        <top>6</top>
+                        <left>15</left>
+                        <bottom>6</bottom>
                         <height>50</height>
                         <font>SymbolPosterBackground</font>
                         <label>[COLOR=FF333333]&#61833;[/COLOR]</label>
                     </control>
                     <control type="label">
-                        <align>right</align>
+                        <align>left</align>
                         <aligny>center</aligny>
                         <width>50</width>
-                        <right>37</right>
-                        <top>6</top>
+                        <left>22</left>
+                        <bottom>6</bottom>
                         <height>50</height>
                         <textcolor>$VAR[WatchedLabelPosterColor]</textcolor>
                         <selectedcolor>$VAR[WatchedLabelPosterColor]</selectedcolor>
@@ -2029,7 +2049,7 @@
             <left>515</left>
             <include content="def_width" condition="$EXP[HomeIsModernMultiWidgets] + !Skin.HasSetting(homemenu.clean.flix) + $PARAM[moveleft] + Skin.HasSetting(old.widgets.movement)">
                 <param name="width" value="$PARAM[containerwidth]" />
-            </include>            
+            </include>
             <include content="def_width" condition="Skin.HasSetting(homemenu.clean.flix)">
                 <param name="width" value="225" />
             </include>
@@ -2227,7 +2247,7 @@
     <include name="def_font">
         <font>$PARAM[font]</font>
     </include>
-    
+
     <include name="def_textheight">
         <height min="$PARAM[height_min]" max="$PARAM[height_max]">auto</height>
     </include>
@@ -3358,6 +3378,160 @@
         </definition>
     </include>
 
+    <include name="IndicatorPosterInfoDialog">
+        <param name="right" value="$PARAM[right]" default="1"/>
+        <param name="top" value="$PARAM[top]" default="1"/>
+        <param name="indicatorbackground" value="$PARAM[indicatorbackground]" default="false"/>
+        <definition>
+        <control type="group">
+            <visible>!Skin.HasSetting(furniture.markers.alternative)</visible>
+            <right>$PARAM[right]</right>
+            <top>$PARAM[top]</top>
+            <control type="label">
+                <align>center</align>
+                <aligny>center</aligny>
+                <width>50</width>
+                <right>7</right>
+                <top>6</top>
+                <height>50</height>
+                <textcolor>$VAR[WatchedBackingColor]</textcolor>
+                <font>SymbolPosterBackground</font>
+                <label>$VAR[WatchedBacking]</label>
+                <visible>$PARAM[indicatorbackground]</visible>
+            </control>
+            <control type="label">
+                <align>center</align>
+                <aligny>center</aligny>
+                <width>50</width>
+                <right>7</right>
+                <top>6</top>
+                <height>50</height>
+                <textcolor>WatchedIcons</textcolor>
+                <selectedcolor>WatchedIcons</selectedcolor>
+                <font>SymbolPoster</font>
+                <label>$VAR[WatchedLabelPoster]</label>
+            </control>
+        </control>
+        <control type="group">
+            <visible>Skin.HasSetting(furniture.markers.alternative) + !Skin.HasSetting(hide.markers)</visible>
+            <right>$PARAM[right]</right>
+            <top>$PARAM[top]</top>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundInprogress]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + ListItem.IsResumable + !Skin.HasSetting(hide.markers.inprogress)</visible>
+            </control>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundWatched]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + !ListItem.IsResumable + String.IsEqual(ListItem.Overlay,OverlayWatched.png) + !Skin.HasSetting(hide.markers.watched)</visible>
+            </control>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundNew]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + !ListItem.IsResumable + [[String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]]] + !Skin.HasSetting(hide.markers.newcontent)</visible>
+            </control>
+            <control type="label">
+                 <right>11</right>
+                 <top>8</top>
+                 <align>center</align>
+                 <label>$VAR[IndicatorFlagLabel]</label>
+                 <width>100</width>
+                 <font>WatchedStates</font>
+                 <textcolor>$VAR[ColorIndicatorBackgroundLabel]</textcolor>
+                 <selectedcolor>$VAR[ColorIndicatorBackgroundLabel]</selectedcolor>
+                 <animation effect="rotate" center="auto" time="0" end="-45" condition="true" loop="false">Conditional</animation>
+            </control>
+        </control>
+        </definition>
+    </include>
+
+    <include name="IndicatorPoster">
+        <param name="right" value="$PARAM[right]" default="1"/>
+        <param name="top" value="$PARAM[top]" default="1"/>
+        <param name="indicatorbackground" value="$PARAM[indicatorbackground]" default="false"/>
+        <definition>
+        <control type="group">
+            <visible>!Skin.HasSetting(furniture.markers.alternative)</visible>
+            <right>$PARAM[right]</right>
+            <top>$PARAM[top]</top>
+            <control type="label">
+                <align>center</align>
+                <aligny>center</aligny>
+                <width>50</width>
+                <right>7</right>
+                <top>6</top>
+                <height>50</height>
+                <textcolor>$VAR[WatchedBackingColor]</textcolor>
+                <font>SymbolPosterBackground</font>
+                <label>$VAR[WatchedBacking]</label>
+                <visible>$PARAM[indicatorbackground]</visible>
+            </control>
+            <control type="label">
+                <align>center</align>
+                <aligny>center</aligny>
+                <width>50</width>
+                <right>7</right>
+                <top>6</top>
+                <height>50</height>
+                <textcolor>WatchedIcons</textcolor>
+                <selectedcolor>WatchedIcons</selectedcolor>
+                <font>SymbolPoster</font>
+                <label>$VAR[WatchedLabelPoster]</label>
+            </control>
+        </control>
+        <control type="group">
+            <visible>Skin.HasSetting(furniture.markers.alternative) + !Skin.HasSetting(hide.markers)</visible>
+            <right>$PARAM[right]</right>
+            <top>$PARAM[top]</top>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundInprogress]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + ListItem.IsResumable + !Skin.HasSetting(hide.markers.inprogress)</visible>
+            </control>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundWatched]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + !ListItem.IsResumable + String.IsEqual(ListItem.Overlay,OverlayWatched.png) + !Skin.HasSetting(hide.markers.watched)</visible>
+            </control>
+            <control type="image">
+                 <right>28</right>
+                 <top>8</top>
+                 <width>100</width>
+                 <height>100</height>
+                 <texture colordiffuse="$VAR[ColorIndicatorBackgroundNew]">misc/overlaywatched.png</texture>
+                 <visible>!Skin.HasSetting(hide.markers) + !ListItem.IsResumable + [[String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]]]] + !Skin.HasSetting(hide.markers.newcontent)</visible>
+            </control>
+            <control type="label">
+                 <right>11</right>
+                 <top>8</top>
+                 <align>center</align>
+                 <label>$VAR[IndicatorFlagLabel]</label>
+                 <width>100</width>
+                 <font>WatchedStates</font>
+                 <textcolor>$VAR[ColorIndicatorBackgroundLabel]</textcolor>
+                 <selectedcolor>$VAR[ColorIndicatorBackgroundLabel]</selectedcolor>
+                 <animation effect="rotate" center="auto" time="0" end="-45" condition="true" loop="false">Conditional</animation>
+            </control>
+        </control>
+        </definition>
+    </include>
+
     <include name="TvShowProviderIcon">
         <control type="image">
             <top>20</top>
@@ -3487,7 +3661,7 @@
         <selectedcolor>WatchedIcons</selectedcolor>
         <font>SymbolPoster</font>
     </include>
-    
+
     <include name="def_weatherfanart.widgets">
         <param name="bordertopbottom" value="$PARAM[bordertopbottom]" default="10"/>
         <param name="borderleftright" value="$PARAM[borderleftright]" default="10"/>
@@ -3783,7 +3957,7 @@
             <visible>!Skin.HasSetting(thumbnails.white)</visible>
         </control>
     </include>
-    
+
     <!-- Includes Widget layouts -->
     <include name="def_widgetposter">
         <param name="indicatorbackground" value="$PARAM[indicatorbackground]" default="false"/>
@@ -4364,7 +4538,7 @@
         <include>more</include>
         </definition>
     </include>
-    
+
     <include name="def_widgetpvrfocus">
         <control type="image">
             <left>3</left>
@@ -4526,8 +4700,8 @@
         </control>
         </definition>
     </include>
-    
-    <include name="def_widgetfocus">       
+
+    <include name="def_widgetfocus">
         <include content="def_widget_glow">
             <param name="glow_height" value="$PARAM[glow_height]" />
             <param name="glow_top" value="$PARAM[glow_top]" />
@@ -4535,7 +4709,7 @@
             <param name="glow_right" value="$PARAM[glow_right]" />
             <param name="glow_zoom" value="$PARAM[glow_zoom]" />
             <param name="id" value="$PARAM[id]" />
-        </include>        
+        </include>
         <control type="group">
             <visible>!Skin.HasSetting(items.focus.zoom)</visible>
             <control type="image">


### PR DESCRIPTION
this works for movies and tv shows : 

### Movies :

![dialoginfo](https://user-images.githubusercontent.com/3939543/132958591-827a12e0-7b35-4c05-8b5c-945055d867e8.jpg)

![director](https://user-images.githubusercontent.com/3939543/132958598-f892ec72-257a-48ef-b403-110444db1538.jpg)

![set](https://user-images.githubusercontent.com/3939543/132958600-a2666cf6-37dd-402f-84ae-1eab43955cf2.jpg)

### TV Shows :  

![tvshow](https://user-images.githubusercontent.com/3939543/132958612-f3a8f9dc-a32f-4657-b0d0-6797862569de.jpg)

![tvstudio](https://user-images.githubusercontent.com/3939543/132958606-6d16b83b-4add-4531-ba4e-766e5200a59c.jpg)

My code is probably not good as usual :D and it stay 2 issues :
- Default watched satuts flag is not display perfectly in good place
- it works with "Similar movie/tvshow" only if "Prefered local information" is disable
