### PR TITLE
Widgets settings 2

### DIFF
--- a/1080i/Includes.xml
+++ b/1080i/Includes.xml
@@ -4097,7 +4097,9 @@
     </include>
 
     <include name="include.widget.square.system">
-        <include>def_widgetsquare_system</include>
+        <include content="def_widgetsquare_system">
+            <param name="label2_visible" value="$PARAM[label2_visible]" />
+        </include>
     </include>
 
     <include name="include.widget.fanart">
@@ -4341,7 +4343,9 @@
     </include>
 
     <include name="include.widget.square.system.focus">
-        <include>def_widgetsquare_system</include>
+        <include content="def_widgetsquare_system">
+            <param name="label2_visible" value="$PARAM[label2_visible]" />
+        </include>
         <include content="def_widgetfocus">
             <param name="id" value="$PARAM[id]"/>
             <param name="glow_height" value="$PARAM[glow_height]" />

--- a/1080i/Includes_Defs.xml
+++ b/1080i/Includes_Defs.xml
@@ -2624,6 +2624,7 @@
         <itemlayout height="325" width="355">
             <include content="include.widget.square.system">
                 <param name="id" value="$PARAM[shortcutsid]"/>
+                <param name="label2_visible" value="$PARAM[label2_visible]"/>
             </include>
         </itemlayout>
     </include>
@@ -2748,6 +2749,7 @@
         <focusedlayout height="325" width="355">
             <include content="include.widget.square.system.focus">
                 <param name="id" value="$PARAM[shortcutsid]"/>
+                <param name="label2_visible" value="$PARAM[label2_visible]"/>
                 <param name="glow_left" value="2"/>
                 <param name="glow_right" value="2"/>
             </include>
@@ -3868,6 +3870,8 @@
     </include>
 
     <include name="def_widgetsquare_system">
+        <param name="label2_visible" value="$PARAM[label2_visible]" default="true"/>
+        <definition>
         <control type="image">
             <left>0</left>
             <top>0</top>
@@ -3920,6 +3924,7 @@
                 <selectedcolor>PanelWhite100</selectedcolor>
                 <label>$INFO[ListItem.Label2]</label>
                 <font>Tiny</font>
+                <visible>$PARAM[label2_visible]</visible>
             </control>
             <control type="label">
                 <top>116</top>
@@ -3978,6 +3983,7 @@
             <texture colordiffuse="BoxWidget" border="4" background="true">common/box21.png</texture>
             <visible>!Skin.HasSetting(thumbnails.white)</visible>
         </control>
+        </definition>
     </include>
 
     <include name="def_widgetfanart">

--- a/1080i/Includes_Home.xml
+++ b/1080i/Includes_Home.xml
@@ -4362,6 +4362,9 @@
     </include>
 
     <include name="InfoSubWidgetSystem">
+        <param name="issettingslayout" value="$PARAM[issettingslayout]" default="false"/>
+        <param name="id" value="$PARAM[id]"/>
+        <definition>
         <include content="def_top" condition="Skin.HasSetting(homemenu.clean.flix) + [Skin.HasSetting(home.oldmenuheight) | Skin.HasSetting(submenu.compatibility)] + !Skin.HasSetting(hidewidgettitle)">
             <param name="top" value="-386" />
         </include>
@@ -4387,7 +4390,11 @@
             <param name="top" value="-427" />
         </include>
         <left>527</left>
-        <include>InfoSubWidgetSystemInclude</include>
+        <include condition="!$PARAM[issettingslayout]">InfoSubWidgetSystemInclude</include>
+        <include condition="$PARAM[issettingslayout]" content="InfoSubWidgetSettingsInclude">
+            <param name="id" value="$PARAM[id]"/>
+        </include>
+        </definition>
     </include>
 
     <include name="MultiWidgetsHeaderLabel">

--- a/1080i/Includes_SubItems_Home.xml
+++ b/1080i/Includes_SubItems_Home.xml
@@ -374,4 +374,29 @@
             </control>
         </control>
     </include>
+    
+    <include name="InfoSubWidgetSettingsInclude">
+        <control type="group">
+            <animation effect="slide" start="0" end="0,385" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + !Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
+            <animation effect="slide" start="0" end="0,415" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
+            <include>Animation.Vertical.Widgets.Label</include>
+            <control type="grouplist">
+                <left>0</left>
+                <orientation>vertical</orientation>
+                <itemgap>14</itemgap>
+                <include content="MultiWidgetsHeaderLabel">
+                    <param name="label" value="$LOCALIZE[5]" />
+                    <param name="visible" value="true" />
+                </include>
+                <include condition="Skin.HasSetting(homemenu.netflix)">IntentButton</include>                
+                <control type="textbox">
+                    <height min="36" max="252">auto</height>
+                    <align>left</align>
+                    <font>Tiny</font>
+                    <textcolor>Dark2</textcolor>
+                    <label>$INFO[Container($PARAM[id]).ListItem.Label2]</label>
+                </control>
+            </control>
+        </control>
+    </include>
 </includes>

--- a/1080i/Includes_SubItems_Home.xml
+++ b/1080i/Includes_SubItems_Home.xml
@@ -390,6 +390,9 @@
                 </include>
                 <include condition="Skin.HasSetting(homemenu.netflix)">IntentButton</include>                
                 <control type="textbox">
+                    <include content="def_height" condition="Skin.HasSetting(homemenu.clean.flix)">
+                        <param name="height" value="216" />
+                    </include>
                     <height min="36" max="252">auto</height>
                     <align>left</align>
                     <font>Tiny</font>

--- a/shortcuts/overrides.xml
+++ b/shortcuts/overrides.xml
@@ -895,6 +895,7 @@
         </node>
         <node label="$LOCALIZE[130]">
             <shortcut widget="systeminfo" type="31452" label="$LOCALIZE[130]" icon="special://skin/extras/icons/sysinfo.png" widgetType="system" widgetTarget="system">$INCLUDE[skinshortcuts-template-SystemInfoContent]</shortcut>
+            <shortcut widget="settings" type="31452" label="$LOCALIZE[5]" icon="special://skin/extras/icons/sysinfo.png" widgetType="system" widgetTarget="system">$INCLUDE[skinshortcuts-template-SettingsInfoContent]</shortcut>
         </node>
         <node label="$LOCALIZE[1034]" condition="String.IsEqual(Window(Home).Property(skinshortcuts-Widget),1)">
             <shortcut widget="mysubmenu" type="31452" label="$LOCALIZE[1034]" icon="DefaultAddon.png" widgetType="addons" widgetTarget="programs">$INCLUDE[skinshortcuts-submenu]</shortcut>

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -789,6 +789,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]1"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <include content="TemplateSubmenuItemLayout" condition="$SKINSHORTCUTS[issubmenulayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]1"/>
@@ -817,6 +818,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]1"/>
                     <param name="shortcutsidshort" value=""/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <include content="TemplateSubmenuFocusLayout" condition="$SKINSHORTCUTS[issubmenulayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]1"/>
@@ -990,6 +992,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]2"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <!-- FocusLayouts -->
                 <include content="TemplateNormalFocusLayout" condition="$SKINSHORTCUTS[isnormallayout]">
@@ -1011,6 +1014,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]2"/>
                     <param name="shortcutsidshort" value=".2"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <content limit="$SKINSHORTCUTS[widgetlimit]" target="$SKINSHORTCUTS[target]" sortby="$SKINSHORTCUTS[sortby]" sortorder="$SKINSHORTCUTS[sort]">$SKINSHORTCUTS[content]</content>
                 <include content="morecontent" condition="Skin.HasSetting(enable.morewidget)">
@@ -1173,6 +1177,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]3"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <!-- FocusLayouts -->
                 <include content="TemplateNormalFocusLayout" condition="$SKINSHORTCUTS[isnormallayout]">
@@ -1194,6 +1199,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]3"/>
                     <param name="shortcutsidshort" value=".3"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <content limit="$SKINSHORTCUTS[widgetlimit]" target="$SKINSHORTCUTS[target]" sortby="$SKINSHORTCUTS[sortby]" sortorder="$SKINSHORTCUTS[sort]">$SKINSHORTCUTS[content]</content>
                 <include content="morecontent" condition="Skin.HasSetting(enable.morewidget)">
@@ -1356,6 +1362,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]4"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <!-- FocusLayouts -->
                 <include content="TemplateNormalFocusLayout" condition="$SKINSHORTCUTS[isnormallayout]">
@@ -1377,6 +1384,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]4"/>
                     <param name="shortcutsidshort" value=".4"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <content limit="$SKINSHORTCUTS[widgetlimit]" target="$SKINSHORTCUTS[target]" sortby="$SKINSHORTCUTS[sortby]" sortorder="$SKINSHORTCUTS[sort]">$SKINSHORTCUTS[content]</content>
                 <include content="morecontent" condition="Skin.HasSetting(enable.morewidget)">
@@ -1539,6 +1547,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]5"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <!-- FocusLayouts -->
                 <include content="TemplateNormalFocusLayout" condition="$SKINSHORTCUTS[isnormallayout]">
@@ -1560,6 +1569,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]5"/>
                     <param name="shortcutsidshort" value=".5"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <content limit="$SKINSHORTCUTS[widgetlimit]" target="$SKINSHORTCUTS[target]" sortby="$SKINSHORTCUTS[sortby]" sortorder="$SKINSHORTCUTS[sort]">$SKINSHORTCUTS[content]</content>
                 <include content="morecontent" condition="Skin.HasSetting(enable.morewidget)">
@@ -1722,6 +1732,7 @@
                 </include>
                 <include content="TemplateSystemItemLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]6"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <!-- FocusLayouts -->
                 <include content="TemplateNormalFocusLayout" condition="$SKINSHORTCUTS[isnormallayout]">
@@ -1743,6 +1754,7 @@
                 <include content="TemplateSystemFocusLayout" condition="$SKINSHORTCUTS[issystemlayout]">
                     <param name="shortcutsid" value="301$SKINSHORTCUTS[id]6"/>
                     <param name="shortcutsidshort" value=".6"/>
+                    <param name="label2_visible" value="!$SKINSHORTCUTS[issettingslayout]"/>
                 </include>
                 <content limit="$SKINSHORTCUTS[widgetlimit]" target="$SKINSHORTCUTS[target]" sortby="$SKINSHORTCUTS[sortby]" sortorder="$SKINSHORTCUTS[sort]">$SKINSHORTCUTS[content]</content>
                 <include content="morecontent" condition="Skin.HasSetting(enable.morewidget)">

--- a/shortcuts/template.xml
+++ b/shortcuts/template.xml
@@ -585,6 +585,91 @@
             </item>
         </controls>
     </other>
+    
+    <!-- Widget for Settings -->
+    <other include="SettingsInfoContent">
+        <controls>
+            <item id="1">
+                <label>14206</label>
+                <label2>31275</label2>
+                <icon>special://skin/extras/icons/paintbrush.png</icon>
+                <onclick>activatewindow(InterfaceSettings)</onclick>
+            </item>
+            <item id="2">
+                <label>14202</label>
+                <label2>31276</label2>
+                <icon>special://skin/extras/icons/tags.png</icon>
+                <onclick>activatewindow(MediaSettings)</onclick>
+            </item>
+            <item id="3">
+                <label>14200</label>
+                <label2>31277</label2>
+                <icon>special://skin/extras/icons/equalizer.png</icon>
+                <onclick>activatewindow(PlayerSettings)</onclick>
+            </item>
+            <item id="12">
+                <label>20077</label>
+                <label2>31166</label2>
+                <icon>special://skin/extras/icons/year.png</icon>
+                <onclick>activatewindow(SkinSettings)</onclick>
+            </item>
+            <item id="8">
+                <label>13000</label>
+                <label2>31161</label2>
+                <icon>special://skin/extras/icons/configure.png</icon>
+                <onclick>activatewindow(SystemSettings)</onclick>
+            </item>
+            <item id="7">
+                <label>14036</label>
+                <label2>31164</label2>
+                <icon>special://skin/extras/icons/network.png</icon>
+                <onclick>activatewindow(servicesettings)</onclick>
+            </item>
+            <item id="9">
+                <label>13200</label>
+                <label2>31165</label2>
+                <icon>special://skin/extras/icons/actor.png</icon>
+                <onclick>activatewindow(Profiles)</onclick>
+            </item>
+            <item id="4">
+                <label>24001</label>
+                <label2>31162</label2>
+                <icon>special://skin/extras/icons/addons.png</icon>
+                <onclick>activatewindow(AddonBrowser)</onclick>
+            </item>
+            <item id="10">
+                <label>130</label>
+                <label2>31167</label2>
+                <icon>special://skin/extras/icons/sysinfo.png</icon>
+                <onclick>activatewindow(7)</onclick>
+            </item>
+            <item id="11">
+                <label>19191</label>
+                <label2>31163</label2>
+                <icon>special://skin/extras/icons/livetv.png</icon>
+                <onclick>activatewindow(pvrsettings)</onclick>
+            </item>
+            <item id="5">
+                <label>LibreELEC $LOCALIZE[5]</label>
+                <label2>31373</label2>
+                <icon>special://skin/extras/icons/libreelec.png</icon>
+                <onclick>RunScript(service.libreelec.settings)</onclick>
+                <visible>System.HasAddon(service.libreelec.settings)</visible>
+            </item>
+            <item id="6">
+                <label>CoreELEC $LOCALIZE[5]</label>
+                <label2>31374</label2>
+                <icon>special://skin/extras/icons/coreelec.png</icon>
+                <onclick>RunScript(service.coreelec.settings)</onclick>
+                <visible>System.HasAddon(service.coreelec.settings)</visible>
+            </item>
+            <item id="14">
+                <label>$LOCALIZE[7]</label>
+                <icon>special://skin/extras/icons/filemanager.png</icon>
+                <onclick>ActivateWindow(filemanager)</onclick>
+            </item>
+        </controls>
+    </other>
 
     <!-- Widget 1 -->
     <other include="widget-vertical.1">
@@ -598,6 +683,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget" value="system">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widget" value="mysubmenu">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="issubmenulayout" tag="property" attribute="name|widget" value="mysubmenu">true</property>
@@ -772,6 +859,8 @@
                     <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
                         <param name="fadecondition" value="!Control.HasFocus(301$SKINSHORTCUTS[id]2) + !Control.HasFocus(301$SKINSHORTCUTS[id]3)"/>
                         <param name="includefadecondition" value="true"/>
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]1"/>
                     </include>
                 </control>
                 <control type="grouplist">
@@ -795,6 +884,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.2" value="weather">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.2" value="system">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget.2" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget.2" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="isweatherlayout" tag="property" attribute="name|widgetTarget.2" value="weather">true</property>
@@ -951,7 +1042,10 @@
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
-                    <include condition="$SKINSHORTCUTS[issystemlayout]">InfoSubWidgetSystem</include>
+                    <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]2" />
+                    </include>
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
@@ -974,6 +1068,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.3" value="weather">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.3" value="system">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget.3" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget.3" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="isweatherlayout" tag="property" attribute="name|widgetTarget.3" value="weather">true</property>
@@ -1129,7 +1225,10 @@
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
-                    <include condition="$SKINSHORTCUTS[issystemlayout]">InfoSubWidgetSystem</include>
+                    <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]3" />
+                    </include>
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
@@ -1152,6 +1251,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.4" value="weather">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.4" value="system">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget.4" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget.4" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="isweatherlayout" tag="property" attribute="name|widgetTarget.4" value="weather">true</property>
@@ -1307,7 +1408,10 @@
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
-                    <include condition="$SKINSHORTCUTS[issystemlayout]">InfoSubWidgetSystem</include>
+                    <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]4" />
+                    </include>
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
@@ -1330,6 +1434,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.5" value="weather">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.5" value="system">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget.5" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget.5" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="isweatherlayout" tag="property" attribute="name|widgetTarget.5" value="weather">true</property>
@@ -1485,7 +1591,10 @@
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
-                    <include condition="$SKINSHORTCUTS[issystemlayout]">InfoSubWidgetSystem</include>
+                    <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]5" />
+                    </include>
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
@@ -1508,6 +1617,8 @@
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.6" value="weather">false</property>
         <property name="isnormallayout" tag="property" attribute="name|widgetTarget.6" value="system">false</property>
         <property name="isnormallayout">true</property>
+        <property name="issettingslayout" tag="property" attribute="name|widget.6" value="settings">true</property>
+        <property name="issettingslayout">false</property>
         <property name="issystemlayout" tag="property" attribute="name|widgetTarget.6" value="system">true</property>
         <property name="issystemlayout">false</property>
         <property name="isweatherlayout" tag="property" attribute="name|widgetTarget.6" value="weather">true</property>
@@ -1663,7 +1774,10 @@
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>
-                    <include condition="$SKINSHORTCUTS[issystemlayout]">InfoSubWidgetSystem</include>
+                    <include condition="$SKINSHORTCUTS[issystemlayout]" content="InfoSubWidgetSystem">
+                        <param name="issettingslayout" value="$SKINSHORTCUTS[issettingslayout]"/>
+                        <param name="id" value="301$SKINSHORTCUTS[id]6" />
+                    </include>
                 </control>
                 <control type="grouplist">
                     <skinshortcuts>visibility</skinshortcuts>


### PR DESCRIPTION
hi, i'm trying to use your skin, but i realized that widgets cannot be set with a small icon, but only with poster, fanart, square, preview, banner. I would very much like to use a much smaller icon as you see from this image:

[https://app.box.com/s/wyyyvj91wxa41kpuv55vu42ib69m4cdc](url)

I hope it's nothing impossible, as you can see with the movie posters below, the search, genre and title buttons above are just ugly with the same size.

Thanks and sorry for the trouble