### PR TITLE
[Fix] fixed issue with OSD LiveTv double icon in some cases

### DIFF
--- a/1080i/DialogSeekBar.xml
+++ b/1080i/DialogSeekBar.xml
@@ -146,7 +146,7 @@
                         <animation effect="slide" delay="10" tween="sine" easing="out" start="-70" end="0" time="200">WindowOpen</animation>
                     </control>
                     <control type="image">
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                        <visible>!VideoPlayer.Content(LiveTV) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <left>-50</left>
                         <top>-240</top>
                         <width>270</width>
@@ -198,7 +198,7 @@
                     </control>
                     <control type="group">
                         <left>253</left>
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                        <visible>!VideoPlayer.Content(LiveTV) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <include>OSDInfoContent</include>
                     </control>
                     <control type="group">
@@ -238,7 +238,7 @@
                         </control>
                     </control>
                     <control type="image">
-                        <visible>!Skin.hasSetting(osd.disableposter) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
+                        <visible>!VideoPlayer.Content(LiveTV) + !Skin.hasSetting(osd.disableposter) + [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <left>0</left>
                         <top>-250</top>
                         <width>270</width>
@@ -345,7 +345,7 @@
                     <top>-870</top>
                     <bottom>50</bottom>
                     <control type="image">
-                        <visible>!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))</visible>
+                        <visible>!VideoPlayer.Content(LiveTV) +  [!String.IsEmpty(Player.Art(tvshow.poster)) | !String.IsEmpty(Player.Art(poster))]</visible>
                         <left>0</left>
                         <top>0</top>
                         <width>270</width>


### PR DESCRIPTION
fix this issue : https://github.com/beatmasterRS/skin.arctic.zephyr.mod/issues/499

works with all display mode "AZR, standard, On Side"
