### PR TITLE
[FIX] show markers unwatched with default indicator don't work

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -157,6 +157,7 @@
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">[COLOR=FF00DD44]&#10003;[/COLOR]</value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !$EXP[IsNewMovie] + !$EXP[IsNewTVShow] + !$EXP[IsNewEpisode] + !Skin.HasSetting(hide.markers.unwatched)">&#61833;</value>
     </variable>
 
     <variable name="IndicatorFlagLabel">

--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -157,7 +157,7 @@
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png) + Skin.HasSetting(hide.markers.watched)"></value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayWatched.png)">[COLOR=FF00DD44]&#10003;[/COLOR]</value>
         <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + [$EXP[IsNewMovie] | $EXP[IsNewTVShow] | $EXP[IsNewEpisode]] + !Skin.HasSetting(hide.markers.newcontent)">[COLOR=ColoredIcons]&#62079;[/COLOR]</value>
-        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !$EXP[IsNewMovie] + !$EXP[IsNewTVShow] + !$EXP[IsNewEpisode] + !Skin.HasSetting(hide.markers.unwatched)">&#61833;</value>
+        <value condition="String.IsEqual(ListItem.Overlay,OverlayUnwatched.png) + !$EXP[IsNewMovie] + !$EXP[IsNewTVShow] + !$EXP[IsNewEpisode] + !Skin.HasSetting(hide.markers.unwatched) + !String.IsEqual(ListItem.Property(LabelMore),more)">&#61833;</value>
     </variable>
 
     <variable name="IndicatorFlagLabel">


### PR DESCRIPTION
show markers unwatched with default indicators don't work :  

![unwatched](https://user-images.githubusercontent.com/3939543/133922850-e52782d2-c703-457f-bfe8-261fc9cbeebe.jpg)

before :  

![screenshot00011](https://user-images.githubusercontent.com/3939543/133922881-a3f0c6b4-ffca-4cf7-a88a-cce0eb6cf6d6.png)

after : 

![screenshot00012](https://user-images.githubusercontent.com/3939543/133922915-0de465c6-7cfa-4509-837d-38a2127432bd.png)





