### PR TITLE
[Video Information Dialog] widgets return to initial position 

### DIFF
--- a/1080i/Includes_Lists.xml
+++ b/1080i/Includes_Lists.xml
@@ -286,8 +286,18 @@
                 <onup condition="Control.HasFocus(50) + !ListItem.IsCollection">SetProperty(down,1)</onup>
                 <onleft>$PARAM[controlid]</onleft>
                 <onright>$PARAM[controlid]</onright>
+                <ondown condition="Integer.IsGreater(Container(50).NumItems,0) + Control.IsVisible(50)">SetFocus(50,0,absolute)</ondown>
+                <ondown condition="Integer.IsGreater(Container(9502).NumItems,0) + Control.IsVisible(9502)">SetFocus(9502,0,absolute)</ondown>
+                <ondown condition="Integer.IsGreater(Container(9503).NumItems,0) + Control.IsVisible(9503)">SetFocus(9503,0,absolute)</ondown>
+                <ondown condition="Integer.IsGreater(Container(9506).NumItems,0) + Control.IsVisible(9506)">SetFocus(9506,0,absolute)</ondown>
+                <ondown condition="Integer.IsGreater(Container(9515).NumItems,0) + Control.IsVisible(9515)">SetFocus(9515,0,absolute)</ondown>
                 <ondown>9000</ondown>
                 <ondown>ClearProperty(down)</ondown>
+                <onback condition="Integer.IsGreater(Container(50).NumItems,0) + Control.IsVisible(50)">SetFocus(50,0,absolute)</onback>
+                <onback condition="Integer.IsGreater(Container(9502).NumItems,0) + Control.IsVisible(9502)">SetFocus(9502,0,absolute)</onback>
+                <onback condition="Integer.IsGreater(Container(9503).NumItems,0) + Control.IsVisible(9503)">SetFocus(9503,0,absolute)</onback>
+                <onback condition="Integer.IsGreater(Container(9506).NumItems,0) + Control.IsVisible(9506)">SetFocus(9506,0,absolute)</onback>
+                <onback condition="Integer.IsGreater(Container(9515).NumItems,0) + Control.IsVisible(9515)">SetFocus(9515,0,absolute)</onback>
                 <onback condition="!Window.IsVisible(script-embuary-person.xml) + !Window.IsVisible(script-embuary-video.xml)">9000</onback>
                 <onback>ClearProperty(down)</onback>
                 <onclick>$PARAM[onclick1]</onclick>
@@ -693,14 +703,14 @@
         <value condition="String.IsEqual(Window(home).Property(extendedtype),tv)">plugin://plugin.video.themoviedb.helper/?info=details&amp;type=tv&amp;query=$INFO[Container(10051).ListItem.Label]</value>
         <value>plugin://plugin.video.themoviedb.helper/?info=details&amp;type=movie&amp;query=$INFO[Container(10051).ListItem.Label]</value>
     </variable>
-    
+
     <include name="Header_PlayListStats">
         <control type="list">
             <include>HiddenListControl</include>
             <content>$VAR[PlayListStatsPath]</content>
         </control>
     </include>
-    
+
     <include name="Header_PlaylistsCountItem">
         <control type="list" id="9986">
             <include>HiddenListControl</include>


### PR DESCRIPTION
Now widget in Video Information Dialog return to initial position by default with BACK or DOWN (Movies / TV shows)

works with :
- Cast of movie
- Movies Similar
- Movies Same Studio
- Movies Same Director
- Movies set

before : 

![6](https://user-images.githubusercontent.com/3939543/134571218-0917077d-af08-4117-9042-fcc0348bb82e.jpg)

![8](https://user-images.githubusercontent.com/3939543/134571243-78f955ed-009e-4647-a0c0-caf21f6d39b9.jpg)

after : 

![7](https://user-images.githubusercontent.com/3939543/134571384-6a5f8a1f-b417-49a2-b44b-9585316c8a33.jpg)



