### PR TITLE
[background] improvement "disable fanart addon" with "music visualisation"

### DIFF
--- a/1080i/MusicVisualisation.xml
+++ b/1080i/MusicVisualisation.xml
@@ -15,7 +15,7 @@
             <aspectratio>scale</aspectratio>
             <include>Dimensions_Fullscreen</include>
             <texture background="true">$INFO[Skin.String(fanart.fallback.music)]</texture>
-            <visible>!String.IsEmpty(Skin.String(fanart.fallback.music)) + [String.IsEmpty(Player.Art(fanart)) | !Skin.HasSetting(musicvis.fanartfallback)] + [String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image)) | Skin.HasSetting(ArtistSlideShow.Disabled)]</visible>
+            <visible>!String.IsEmpty(Skin.String(fanart.fallback.music)) + [String.IsEmpty(Player.Art(fanart))  | [Skin.HasSetting(disable.background.addons.fanart) + String.Contains(Player.Art(fanart),addons) + [String.Contains(Player.Art(fanart),plugin) | String.Contains(Player.Art(fanart),script) | String.Contains(Player.Art(fanart),service)]] | !Skin.HasSetting(musicvis.fanartfallback)] + [String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image)) | Skin.HasSetting(ArtistSlideShow.Disabled)]</visible>
             <animation effect="fade" start="100" end="65" time="0" condition="Skin.HasSetting(OSDVisualisation.ShowFanart)">Conditional</animation>
             <animation effect="zoom" start="110" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
             <animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
@@ -24,7 +24,7 @@
             <aspectratio>scale</aspectratio>
             <include>Dimensions_Fullscreen</include>
             <texture background="true">$INFO[Player.Art(fanart)]</texture>
-            <visible>Skin.HasSetting(musicvis.fanartfallback) + !String.IsEmpty(Player.Art(fanart)) + [String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image)) | !System.AddonIsEnabled(script.artistslideshow) | Skin.HasSetting(ArtistSlideShow.Disabled)]</visible>
+            <visible>Skin.HasSetting(musicvis.fanartfallback) + !String.IsEmpty(Player.Art(fanart)) + [String.IsEmpty(Window(Visualisation).Property(ArtistSlideshow.Image)) | !System.AddonIsEnabled(script.artistslideshow) | Skin.HasSetting(ArtistSlideShow.Disabled)] + [!Skin.HasSetting(disable.background.addons.fanart) | [Skin.HasSetting(disable.background.addons.fanart) + !String.Contains(Player.Art(fanart),addons) + ![String.Contains(Player.Art(fanart),plugin) | String.Contains(Player.Art(fanart),script) | String.Contains(Player.Art(fanart),service)]]]</visible>
             <animation effect="fade" start="100" end="65" time="0" condition="Skin.HasSetting(OSDVisualisation.ShowFanart)">Conditional</animation>
             <animation effect="zoom" start="110" end="130" center="auto" time="10000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
             <animation effect="slide" start="-30,-30" end="30,30" time="6000" tween="sine" easing="inout" pulse="true" condition="Skin.HasSetting(ArtistSlideshow.Animate)">Conditional</animation>
@@ -60,7 +60,7 @@
                 <textcolor>77ffffff</textcolor>
                 <align>left</align>
                 <scrollspeed>55</scrollspeed>
-                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>                
+                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>
                 <animation effect="fade" start="0" end="100" time="950" delay="500" tween="cubic" easing="inout">Visible</animation>
                 <animation effect="fade" end="0" start="100" time="350">Hidden</animation>
             </control>
@@ -75,7 +75,7 @@
                 <textcolor>44cccccc</textcolor>
                 <align>left</align>
                 <scrollspeed>100</scrollspeed>
-                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>                
+                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>
                 <animation effect="fade" start="0" end="100" time="950" delay="500" tween="cubic" easing="inout">Visible</animation>
                 <animation effect="fade" end="0" start="100" time="350">Hidden</animation>
             </control>
@@ -91,7 +91,7 @@
                 <align>left</align>
                 <scrollspeed>80</scrollspeed>
                 <visible>!Pvr.IsPlayingRadio</visible>
-                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>                
+                <visible>Integer.IsGreater(MusicPlayer.Time,0) + !String.IsEqual(Player.TimeRemaining(hh:mm:ss),00:00:01)</visible>
                 <animation effect="fade" start="0" end="100" time="950" delay="500" tween="cubic" easing="inout">Visible</animation>
                 <animation effect="fade" end="0" start="100" time="350">Hidden</animation>
             </control>
@@ -122,11 +122,11 @@
             <visible>!Window.IsVisible(musicosd)</visible>
             <visible>Window.IsVisible(script-cu-lrclyrics-main.xml) | Player.Seeking | Player.DisplayAfterSeek | Player.Paused | Player.Forwarding | Player.Rewinding | Player.ShowInfo</visible>
             <animation effect="slide" start="0,110" end="0" time="150">Visible</animation>
-            <animation effect="slide" start="0,110" end="0" time="150">WindowOpen</animation>            
+            <animation effect="slide" start="0,110" end="0" time="150">WindowOpen</animation>
             <animation type="Hidden">
                 <effect type="fade" start="100" end="0" time="150"/>
                 <effect type="slide" end="0,160" start="0" time="150"/>
-            </animation>            
+            </animation>
             <animation effect="slide" end="0,120" start="0" time="150" condition="Window.IsVisible(script-cu-lrclyrics-main.xml) + Skin.HasSetting(hideseekbaronlyrics) + !Skin.HasSetting(osd.usethemeNewOSDMusic)">Conditional</animation>
             <animation effect="slide" end="0,280" start="0" time="150" condition="Window.IsVisible(script-cu-lrclyrics-main.xml) + Skin.HasSetting(hideseekbaronlyrics) + Skin.HasSetting(osd.usethemeNewOSDMusic)">Conditional</animation>
             <animation effect="slide" end="0,160" start="0" time="150">WindowClose</animation>
@@ -304,7 +304,7 @@
                 <control type="grouplist">
                     <orientation>horizontal</orientation>
                     <width>190</width>
-                    <bottom>17</bottom>   
+                    <bottom>17</bottom>
                     <height>30</height>
                     <itemgap>10</itemgap>
                     <include content="MusicVisualisation_RatingStars">
@@ -365,7 +365,7 @@
                     </control>
                 </control>
             </control>
-            
+
         </control>
         <control type="group">
             <visible>Skin.HasSetting(AlternativeCd) + Skin.HasSetting(ShowMusicCd)</visible>


### PR DESCRIPTION
extended "disable fanart addon" with "music visualisation"".

eg: addon "radio.be"

before : "disable fanart addon" have no effect with "music visualisation"

![1](https://user-images.githubusercontent.com/3939543/136032433-9b3b91f2-4a49-4f7a-a8b6-2abe73c55848.jpg)

after : "disable fanart addon" works with "music visualisation" 

![3](https://user-images.githubusercontent.com/3939543/136032946-31df1a54-0497-4bfa-b967-8e8221a944d9.jpg)

AS3 (yes/no?) => Fanart (yes/no?) => "fanart addon" (yes/no?) => "Music fallback image" (yes/no?) => menu background (yes/no?) => black screen
