### PR TITLE
Add season number to Wide episodes view

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -407,6 +407,11 @@
         <value condition="String.IsEmpty(ListItem.Episode)">$NUMBER[0]$NUMBER[0]</value>
     </variable>
 
+    <variable name="LabelSeason">
+        <value condition="!String.IsEmpty(ListItem.Season)">$INFO[ListItem.Season]</value>
+        <value condition="String.IsEmpty(ListItem.Season)">$NUMBER[0]</value>
+    </variable>
+
     <variable name="LabelDirector">
         <value condition="!String.IsEmpty(ListItem.Label) + Container.Content(songs)">$INFO[ListItem.Label]</value>
         <value condition="!String.IsEmpty(ListItem.Artist) + Container.Content(albums)">$INFO[ListItem.Artist]</value>

--- a/1080i/View_54_Banner.xml
+++ b/1080i/View_54_Banner.xml
@@ -72,6 +72,7 @@
                     <itemlayout width="1288" height="106" condition="Container.Content(episodes)">
                         <control type="group">
                             <posy>-35</posy>
+                            <animation effect="slide" end="-54,0" time="0" condition="!Integer.IsGreater(ListItem.Season,9)">Conditional</animation>
                             <control type="label">
                                 <font>EpisodeNumber</font>
                                 <top>20</top>
@@ -86,7 +87,7 @@
                             </control>
                             <control type="label">
                                 <top>47</top>
-                                <left>790</left>
+                                <left>800</left>
                                 <right>54</right>
                                 <height>40</height>
                                 <align>left</align>
@@ -98,7 +99,7 @@
                                 <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
                             </control>
                             <control type="label">
-                                <left>792</left>
+                                <left>802</left>
                                 <centertop>103</centertop>
                                 <width>50</width>
                                 <height>50</height>
@@ -110,7 +111,7 @@
                             </control>
                             <control type="label">
                                 <top>85</top>
-                                <left>825</left>
+                                <left>835</left>
                                 <right>50</right>
                                 <height>40</height>
                                 <align>left</align>
@@ -422,54 +423,57 @@
                                 <texture colordiffuse="Box2" border="4">common/box21.png</texture>
                                 <visible>!Skin.HasSetting(thumbnails.white)</visible>
                             </control>
-                            <control type="label">
-                                <font>EpisodeNumber</font>
-                                <top>20</top>
-                                <left>530</left>
-                                <width>250</width>
-                                <height>40</height>
-                                <align>right</align>
-                                <aligny>top</aligny>
-                                <label>$VAR[LabelSeason]x$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
-                                <textcolor>Light1</textcolor>
-                                <selectedcolor>Light1</selectedcolor>
-                            </control>
-                            <control type="label">
-                                <top>47</top>
-                                <left>790</left>
-                                <right>54</right>
-                                <height>40</height>
-                                <align>left</align>
-                                <aligny>top</aligny>
-                                <label>$VAR[LabelTitle]</label>
-                                <font>SmallBold</font>
-                                <textcolor>Light1</textcolor>
-                                <selectedcolor>Light1</selectedcolor>
-                                <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
-                            </control>
-                            <control type="label">
-                                <left>792</left>
-                                <centertop>107</centertop>
-                                <width>50</width>
-                                <height>50</height>
-                                <textcolor>Light1</textcolor>
-                                <font>SymbolPoster</font>
-                                <label>$VAR[WatchedLabelList]</label>
-                                <selectedcolor>Light1</selectedcolor>
-                                <visible>!String.IsEqual(ListItem.Label,..)</visible>
-                            </control>
-                            <control type="label">
-                                <top>90</top>
-                                <left>825</left>
-                                <right>50</right>
-                                <height>40</height>
-                                <align>left</align>
-                                <aligny>top</aligny>
-                                <label fallback="19055">$VAR[LabelYear,,  •  ]$VAR[LabelDuration,,  •  ]$VAR[RatingLabel]</label>
-                                <font>Tiny</font>
-                                <textcolor>Light1</textcolor>
-                                <selectedcolor>Light1</selectedcolor>
-                                <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
+                            <control type="group">
+                                <animation effect="slide" end="-54,0" time="0" condition="!Integer.IsGreater(ListItem.Season,9)">Conditional</animation>
+                                <control type="label">
+                                    <font>EpisodeNumber</font>
+                                    <top>20</top>
+                                    <left>530</left>
+                                    <width>250</width>
+                                    <height>40</height>
+                                    <align>right</align>
+                                    <aligny>top</aligny>
+                                    <label>$VAR[LabelSeason]x$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
+                                    <textcolor>Light1</textcolor>
+                                    <selectedcolor>Light1</selectedcolor>
+                                </control>
+                                <control type="label">
+                                    <top>47</top>
+                                    <left>800</left>
+                                    <right>54</right>
+                                    <height>40</height>
+                                    <align>left</align>
+                                    <aligny>top</aligny>
+                                    <label>$VAR[LabelTitle]</label>
+                                    <font>SmallBold</font>
+                                    <textcolor>Light1</textcolor>
+                                    <selectedcolor>Light1</selectedcolor>
+                                    <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
+                                </control>
+                                <control type="label">
+                                    <left>802</left>
+                                    <centertop>107</centertop>
+                                    <width>50</width>
+                                    <height>50</height>
+                                    <textcolor>Light1</textcolor>
+                                    <font>SymbolPoster</font>
+                                    <label>$VAR[WatchedLabelList]</label>
+                                    <selectedcolor>Light1</selectedcolor>
+                                    <visible>!String.IsEqual(ListItem.Label,..)</visible>
+                                </control>
+                                <control type="label">
+                                    <top>90</top>
+                                    <left>835</left>
+                                    <right>50</right>
+                                    <height>40</height>
+                                    <align>left</align>
+                                    <aligny>top</aligny>
+                                    <label fallback="19055">$VAR[LabelYear,,  •  ]$VAR[LabelDuration,,  •  ]$VAR[RatingLabel]</label>
+                                    <font>Tiny</font>
+                                    <textcolor>Light1</textcolor>
+                                    <selectedcolor>Light1</selectedcolor>
+                                    <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
+                                </control>
                             </control>
                             <control type="textbox">
                                 <top>140</top>

--- a/1080i/View_54_Banner.xml
+++ b/1080i/View_54_Banner.xml
@@ -76,17 +76,17 @@
                                 <font>EpisodeNumber</font>
                                 <top>20</top>
                                 <left>530</left>
-                                <width>180</width>
+                                <width>250</width>
                                 <height>40</height>
-                                <align>left</align>
+                                <align>right</align>
                                 <aligny>top</aligny>
-                                <label>$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
+                                <label>$VAR[LabelSeason]x$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
                                 <textcolor>Dark1</textcolor>
                                 <selectedcolor>Dark1</selectedcolor>
                             </control>
                             <control type="label">
                                 <top>47</top>
-                                <left>650</left>
+                                <left>790</left>
                                 <right>54</right>
                                 <height>40</height>
                                 <align>left</align>
@@ -98,7 +98,7 @@
                                 <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
                             </control>
                             <control type="label">
-                                <left>652</left>
+                                <left>792</left>
                                 <centertop>103</centertop>
                                 <width>50</width>
                                 <height>50</height>
@@ -110,7 +110,7 @@
                             </control>
                             <control type="label">
                                 <top>85</top>
-                                <left>685</left>
+                                <left>825</left>
                                 <right>50</right>
                                 <height>40</height>
                                 <align>left</align>
@@ -426,17 +426,17 @@
                                 <font>EpisodeNumber</font>
                                 <top>20</top>
                                 <left>530</left>
-                                <width>180</width>
+                                <width>250</width>
                                 <height>40</height>
-                                <align>left</align>
+                                <align>right</align>
                                 <aligny>top</aligny>
-                                <label>$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
+                                <label>$VAR[LabelSeason]x$VAR[LabelEpisodeZero]$INFO[ListItem.Episode]</label>
                                 <textcolor>Light1</textcolor>
                                 <selectedcolor>Light1</selectedcolor>
                             </control>
                             <control type="label">
                                 <top>47</top>
-                                <left>650</left>
+                                <left>790</left>
                                 <right>54</right>
                                 <height>40</height>
                                 <align>left</align>
@@ -448,7 +448,7 @@
                                 <animation effect="slide" start="0" end="50" condition="Integer.IsGreater(ListItem.Episode,99) | [Integer.IsGreater(ListItem.Episode,9) + String.Contains(ListItem.Episode,S)]">Conditional</animation>
                             </control>
                             <control type="label">
-                                <left>652</left>
+                                <left>792</left>
                                 <centertop>107</centertop>
                                 <width>50</width>
                                 <height>50</height>
@@ -460,7 +460,7 @@
                             </control>
                             <control type="label">
                                 <top>90</top>
-                                <left>685</left>
+                                <left>825</left>
                                 <right>50</right>
                                 <height>40</height>
                                 <align>left</align>


### PR DESCRIPTION
This allows flattened episode lists to be usable, otherwise there's no way to distinguish between same numbered episodes across different seasons.