### PR TITLE
[Fix] choice default discart music / video don't works if discart.png is exist

### DIFF
--- a/1080i/Includes_Images.xml
+++ b/1080i/Includes_Images.xml
@@ -370,17 +370,17 @@
     </variable>
 
     <variable name="MusicDiscart">
+        <value condition="Skin.HasSetting(osd.music.disc.fake.cd) + !String.IsEmpty(Player.Art(Thumb))">$INFO[Player.Art(thumb)]</value>
+        <value condition="Skin.HasSetting(osd.music.disc.fallback.vinyl)">misc/vinyl.png</value>
         <value condition="!String.IsEmpty(Player.Art(album.discart))">$INFO[Player.Art(album.discart)]</value>
         <value condition="!String.IsEmpty(Player.Art(discart))">$INFO[Player.Art(discart)]</value>
-        <value condition="Skin.HasSetting(osd.music.disc.fallback.vinyl)">misc/vinyl.png</value>
-        <value condition="!String.IsEmpty(Player.Art(Thumb)) + Skin.HasSetting(osd.music.disc.fake.cd)">$INFO[Player.Art(thumb)]</value>
         <value>misc/default_cd.png</value>
     </variable>
 
     <variable name="VideoDiscart">
-        <value condition="!String.IsEmpty(Player.Art(discart))">$INFO[Player.Art(discart)]</value>
-        <value condition="Skin.HasSetting(home.video.disc.fallback.bluray)">misc/bd.png</value>
         <value condition="!String.IsEmpty(Player.Art(Thumb)) + Skin.HasSetting(home.video.disc.fake.bluray)">$VAR[PlayerPoster]</value>
+        <value condition="Skin.HasSetting(home.video.disc.fallback.bluray)">misc/bd.png</value>
+        <value condition="!String.IsEmpty(Player.Art(discart))">$INFO[Player.Art(discart)]</value>
         <value>misc/default_cd.png</value>
     </variable>
 


### PR DESCRIPTION
before : 

choice "fake cd" / "Vinyl" / "Blueray" / "fake bluray" in skin settings or music/video visualisation settings  have no effect if discart.png is exist

backport to nexus can be usefull. tell me ...