### PR TITLE
[Fix] Widgets fade animation disable don't works for "system info" and "settings" widgets

### DIFF
--- a/1080i/Includes_SubItems_Home.xml
+++ b/1080i/Includes_SubItems_Home.xml
@@ -302,7 +302,7 @@
         <control type="group">
             <animation effect="slide" start="0" end="0,385" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + !Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
             <animation effect="slide" start="0" end="0,415" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
-            <include>Animation.Vertical.Widgets.Label</include>
+            <include condition="!Skin.HasSetting(widgets.fade)">Animation.Vertical.Widgets.Label</include>
             <control type="grouplist">
                 <left>0</left>
                 <orientation>vertical</orientation>
@@ -397,7 +397,7 @@
         <control type="group">
             <animation effect="slide" start="0" end="0,385" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + !Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
             <animation effect="slide" start="0" end="0,415" time="0" condition="[Integer.IsEqual(Container(301).NumItems,1) + !String.IsEqual(Container(300).ListItem.Property(widgetFullscreen),yes)] +  !Skin.HasSetting(homemenu.netflix) + Skin.HasSetting(home.widgets.show.reflections)">Conditional</animation>
-            <include>Animation.Vertical.Widgets.Label</include>
+            <include condition="!Skin.HasSetting(widgets.fade)">Animation.Vertical.Widgets.Label</include>
             <control type="grouplist">
                 <left>0</left>
                 <orientation>vertical</orientation>


### PR DESCRIPTION
"Widgets fade animation" disable have no effect for "system info" and "settings" Widget : 

![2023-03-10_072946](https://user-images.githubusercontent.com/3939543/224242530-29e59d51-01c2-48f5-b021-5bb5258bf3ac.jpg)

Before : 

![2023-03-10_072910](https://user-images.githubusercontent.com/3939543/224242670-3f4eea50-c08e-43a9-9d90-518a565816ff.jpg)

After : 

![2023-03-10_073858](https://user-images.githubusercontent.com/3939543/224242706-b00d2712-94b7-4036-9c4b-acedf13e521b.jpg)


