### PR TITLE
[Code] Fix unmatched parentheses

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -178,7 +178,7 @@
     </variable>
     
     <variable name="IndicatorFlagLabelIsTVShowInProgress">
-        <value condition="Skin.HasSetting(markers.inprogress.percentage) + !String.IsEmpty(ListItem.Property(WatchedEpisodePercent)">$INFO[ListItem.Property(WatchedEpisodePercent),,%]</value>
+        <value condition="Skin.HasSetting(markers.inprogress.percentage) + !String.IsEmpty(ListItem.Property(WatchedEpisodePercent))">$INFO[ListItem.Property(WatchedEpisodePercent),,%]</value>
         <value>$INFO[ListItem.Property(WatchedEpisodes)]/$INFO[ListItem.Property(TotalEpisodes)]</value>
     </variable>
     
@@ -2014,7 +2014,7 @@
     </variable>
     
     <variable name="Label_Music_Duration_50">
-        <value condition="String.IsEqual(Container.SortMethod,$LOCALIZE[567]">$INFO[ListItem.PlayCount]</value>
+        <value condition="String.IsEqual(Container.SortMethod,$LOCALIZE[567])">$INFO[ListItem.PlayCount]</value>
         <value>$INFO[ListItem.Duration]</value>
     </variable>
     


### PR DESCRIPTION
I detected an unclosed parentheses due to this appearing in the logs:

> 2023-03-13 04:20:24.332 T:18244   error <general>: unmatched parentheses in string.isequal(container.sortmethod,contador de reproducci��n

These special characters broke a log parser that detects errors for me.

