### PR TITLE
Add missing close parenthesis to Includes_Labels.xml

### DIFF
--- a/1080i/Includes_Labels.xml
+++ b/1080i/Includes_Labels.xml
@@ -185,7 +185,7 @@
     
     <variable name="IndicatorFlagLabelIsTVShowInProgress301">
         <value condition="Skin.HasSetting(markers.inprogress.tvshow.label)">$LOCALIZE[31492]</value>
-        <value condition="Skin.HasSetting(markers.inprogress.percentage) + !String.IsEmpty(Container(301).ListItem.Property(WatchedEpisodePercent)">$INFO[Container(301).ListItem.Property(WatchedEpisodePercent),,%]</value>
+        <value condition="Skin.HasSetting(markers.inprogress.percentage) + !String.IsEmpty(Container(301).ListItem.Property(WatchedEpisodePercent))">$INFO[Container(301).ListItem.Property(WatchedEpisodePercent),,%]</value>
         <value>$INFO[Container(301).ListItem.Property(WatchedEpisodes)]/$INFO[Container(301).ListItem.Property(TotalEpisodes)]</value>
     </variable>
 


### PR DESCRIPTION
(Re)loading the skin would throw an error into the log and any changes to the home menu layout would not be applied:
```
2023-06-10 13:17:29.190 T:408450   error <general>: unmatched parentheses in string.isempty(container(301).listitem.property(watchedepisodepercent)
```

This PR adds the missing parenthesis to `Includes_Labels.xml`.